### PR TITLE
Drop expired I2NP fragments

### DIFF
--- a/emissary-core/src/tunnel/fragment.rs
+++ b/emissary-core/src/tunnel/fragment.rs
@@ -37,11 +37,11 @@ use futures::future::{BoxFuture, FutureExt};
 
 /// Message expiration threshold.
 ///
-/// If all the fragments of a message have not been received within 30 seconds,
+/// If all the fragments of a message have not been received within 45 seconds,
 /// the [`Fragment`] is destroyed.
 ///
 /// This is to prevent unbounded accumulation of incomplete I2NP messages.
-const MSG_EXPIRATION_THRESHOLD: Duration = Duration::from_secs(10);
+const MSG_EXPIRATION_THRESHOLD: Duration = Duration::from_secs(45);
 
 /// Garbage collection interval.
 const GARBAGE_COLLECTION_INTERVAL: Duration = Duration::from_secs(45);

--- a/emissary-core/src/tunnel/fragment.rs
+++ b/emissary-core/src/tunnel/fragment.rs
@@ -289,7 +289,7 @@ impl<R: Runtime> Future for FragmentHandler<R> {
                 self.messages.get(message_id).expect("to exist").created.elapsed();
 
             self.next_expiration_timer = Some(Box::pin(R::delay(
-                MSG_EXPIRATION_THRESHOLD - next_fragment_elapsed,
+                MSG_EXPIRATION_THRESHOLD.saturating_sub(next_fragment_elapsed),
             )));
         } else {
             self.next_expiration_timer = None;

--- a/emissary-core/src/tunnel/fragment.rs
+++ b/emissary-core/src/tunnel/fragment.rs
@@ -273,15 +273,12 @@ impl<R: Runtime> Future for FragmentHandler<R> {
 
         // TODO: In rust 1.86 this can become `pop_if`
         while let Some(message_id) = self.message_first_seen_queue.front().copied() {
-            match self.messages.entry(message_id) {
-                Entry::Occupied(fragment_entry) => {
-                    if fragment_entry.get().created.elapsed() >= MSG_EXPIRATION_THRESHOLD {
-                        fragment_entry.remove();
-                    } else {
-                        break;
-                    }
+            if let Entry::Occupied(fragment_entry) = self.messages.entry(message_id) {
+                if fragment_entry.get().created.elapsed() >= MSG_EXPIRATION_THRESHOLD {
+                    fragment_entry.remove();
+                } else {
+                    break;
                 }
-                Entry::Vacant(_) => {}
             }
 
             self.message_first_seen_queue.pop_front();
@@ -577,7 +574,7 @@ mod tests {
         let message = MessageBuilder::standard()
             .with_expiration(expiration)
             .with_message_type(MessageType::Data)
-            .with_message_id(1338u32)
+            .with_message_id(1337u32)
             .with_payload(&vec![0u8; 1337])
             .build();
         let mut fragments = split(4, message);

--- a/emissary-core/src/tunnel/hop/inbound.rs
+++ b/emissary-core/src/tunnel/hop/inbound.rs
@@ -54,12 +54,12 @@ use core::{
 const LOG_TARGET: &str = "emissary::tunnel::ibep";
 
 /// Inbound tunnel.
-pub struct InboundTunnel {
+pub struct InboundTunnel<R: Runtime> {
     /// Tunnel expiration timer.
     expiration_timer: BoxFuture<'static, (TunnelId, TunnelId)>,
 
     /// Fragment handler.
-    fragment: FragmentHandler,
+    fragment: FragmentHandler<R>,
 
     /// Tunnel pool handle.
     handle: TunnelPoolContextHandle,
@@ -77,7 +77,7 @@ pub struct InboundTunnel {
     tunnel_id: TunnelId,
 }
 
-impl InboundTunnel {
+impl<R: Runtime> InboundTunnel<R> {
     /// Get gateway information of the inbound tunnel.
     ///
     /// Returns a `(RouterId, TunnelId)` tuple, allowing OBEP to route the message correctly.
@@ -203,8 +203,9 @@ impl InboundTunnel {
                 } = message.message_kind
                 {
                     match delivery_instructions {
-                        DeliveryInstructions::Local =>
-                            return Message::parse_standard(message.message),
+                        DeliveryInstructions::Local => {
+                            return Message::parse_standard(message.message)
+                        }
                         delivery_instructions => {
                             tracing::warn!(
                                 target: LOG_TARGET,
@@ -266,13 +267,8 @@ impl InboundTunnel {
     }
 }
 
-impl Tunnel for InboundTunnel {
-    fn new<R: Runtime>(
-        name: Str,
-        tunnel_id: TunnelId,
-        receiver: ReceiverKind,
-        hops: Vec<TunnelHop>,
-    ) -> Self {
+impl<R: Runtime> Tunnel for InboundTunnel<R> {
+    fn new(name: Str, tunnel_id: TunnelId, receiver: ReceiverKind, hops: Vec<TunnelHop>) -> Self {
         let (message_rx, handle) = receiver.inbound();
 
         // hop must exist since it was created by us
@@ -310,7 +306,7 @@ impl Tunnel for InboundTunnel {
     }
 }
 
-impl Future for InboundTunnel {
+impl<R: Runtime> Future for InboundTunnel<R> {
     type Output = (TunnelId, TunnelId);
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -347,6 +343,10 @@ impl Future for InboundTunnel {
                 },
             }
         }
+        // poll fragment handler
+        //
+        // the futures don't return anything but must be polled so they make progress
+        let _ = self.fragment.poll_unpin(cx);
 
         self.expiration_timer.poll_unpin(cx)
     }

--- a/emissary-core/src/tunnel/hop/inbound.rs
+++ b/emissary-core/src/tunnel/hop/inbound.rs
@@ -343,6 +343,7 @@ impl<R: Runtime> Future for InboundTunnel<R> {
                 },
             }
         }
+
         // poll fragment handler
         //
         // the futures don't return anything but must be polled so they make progress
@@ -366,12 +367,14 @@ mod tests {
     #[test]
     fn hop_roles() {
         assert_eq!(
-            InboundTunnel::hop_roles(NonZeroUsize::new(1).unwrap()).collect::<Vec<_>>(),
+            InboundTunnel::<MockRuntime>::hop_roles(NonZeroUsize::new(1).unwrap())
+                .collect::<Vec<_>>(),
             vec![HopRole::InboundGateway]
         );
 
         assert_eq!(
-            InboundTunnel::hop_roles(NonZeroUsize::new(3).unwrap()).collect::<Vec<_>>(),
+            InboundTunnel::<MockRuntime>::hop_roles(NonZeroUsize::new(3).unwrap())
+                .collect::<Vec<_>>(),
             vec![
                 HopRole::InboundGateway,
                 HopRole::Participant,

--- a/emissary-core/src/tunnel/hop/mod.rs
+++ b/emissary-core/src/tunnel/hop/mod.rs
@@ -20,7 +20,6 @@ use crate::{
     crypto::StaticPublicKey,
     i2np::{HopRole, Message},
     primitives::{MessageId, RouterId, Str, TunnelId},
-    runtime::Runtime,
     tunnel::{
         noise::{NoiseContext, OutboundSession},
         pool::TunnelPoolContextHandle,
@@ -92,12 +91,7 @@ pub enum TunnelDirection {
 /// Common interface for local tunnels (initiated by us).
 pub trait Tunnel: Send {
     /// Create new [`Tunnel`].
-    fn new<R: Runtime>(
-        name: Str,
-        tunnel_id: TunnelId,
-        receiver: ReceiverKind,
-        hops: Vec<TunnelHop>,
-    ) -> Self;
+    fn new(name: Str, tunnel_id: TunnelId, receiver: ReceiverKind, hops: Vec<TunnelHop>) -> Self;
 
     /// Get an iterator of hop roles for the tunnel participants.
     fn hop_roles(num_hops: NonZeroUsize) -> impl Iterator<Item = HopRole>;
@@ -149,8 +143,8 @@ impl<T: Tunnel> TunnelBuilder<T> {
     }
 
     // Build new tunnel from provided hops.
-    pub fn build<R: Runtime>(self) -> T {
-        T::new::<R>(
+    pub fn build(self) -> T {
+        T::new(
             self.name,
             self.tunnel_id,
             self.receiver,

--- a/emissary-core/src/tunnel/hop/outbound.rs
+++ b/emissary-core/src/tunnel/hop/outbound.rs
@@ -189,12 +189,7 @@ impl<R: Runtime> OutboundTunnel<R> {
 }
 
 impl<R: Runtime> Tunnel for OutboundTunnel<R> {
-    fn new<U>(
-        name: Str,
-        tunnel_id: TunnelId,
-        _receiver: ReceiverKind,
-        hops: Vec<TunnelHop>,
-    ) -> Self {
+    fn new(name: Str, tunnel_id: TunnelId, _receiver: ReceiverKind, hops: Vec<TunnelHop>) -> Self {
         // generate random padding bytes used in `TunnelData` messages
         let padding_bytes = {
             let mut padding_bytes = [0u8; 1028];

--- a/emissary-core/src/tunnel/hop/pending.rs
+++ b/emissary-core/src/tunnel/hop/pending.rs
@@ -732,20 +732,22 @@ mod test {
         let (_tx, rx) = channel(64);
 
         let (pending_tunnel, next_router, message) =
-            PendingTunnel::<InboundTunnel>::create_tunnel::<MockRuntime>(TunnelBuildParameters {
-                hops: hops.clone(),
-                name: Str::from("tunnel-pool"),
-                noise: local_noise,
-                message_id,
-                tunnel_info: TunnelInfo::Inbound {
-                    tunnel_id,
-                    router_id: local_hash,
+            PendingTunnel::<InboundTunnel<MockRuntime>>::create_tunnel::<MockRuntime>(
+                TunnelBuildParameters {
+                    hops: hops.clone(),
+                    name: Str::from("tunnel-pool"),
+                    noise: local_noise,
+                    message_id,
+                    tunnel_info: TunnelInfo::Inbound {
+                        tunnel_id,
+                        router_id: local_hash,
+                    },
+                    receiver: ReceiverKind::Inbound {
+                        message_rx: rx,
+                        handle,
+                    },
                 },
-                receiver: ReceiverKind::Inbound {
-                    message_rx: rx,
-                    handle,
-                },
-            })
+            )
             .unwrap();
 
         let message = match transit_managers[0].0.handle_message(message).unwrap().next() {
@@ -1401,20 +1403,22 @@ mod test {
         let (_tx, rx) = channel(64);
 
         let (pending_tunnel, next_router, message) =
-            PendingTunnel::<InboundTunnel>::create_tunnel::<MockRuntime>(TunnelBuildParameters {
-                hops: hops.clone(),
-                name: Str::from("tunnel-pool"),
-                noise: local_noise,
-                message_id,
-                tunnel_info: TunnelInfo::Inbound {
-                    tunnel_id,
-                    router_id: local_hash,
+            PendingTunnel::<InboundTunnel<MockRuntime>>::create_tunnel::<MockRuntime>(
+                TunnelBuildParameters {
+                    hops: hops.clone(),
+                    name: Str::from("tunnel-pool"),
+                    noise: local_noise,
+                    message_id,
+                    tunnel_info: TunnelInfo::Inbound {
+                        tunnel_id,
+                        router_id: local_hash,
+                    },
+                    receiver: ReceiverKind::Inbound {
+                        message_rx: rx,
+                        handle,
+                    },
                 },
-                receiver: ReceiverKind::Inbound {
-                    message_rx: rx,
-                    handle,
-                },
-            })
+            )
             .unwrap();
 
         let message = match transit_managers[0].0.handle_message(message).unwrap().next() {

--- a/emissary-core/src/tunnel/hop/pending.rs
+++ b/emissary-core/src/tunnel/hop/pending.rs
@@ -397,8 +397,9 @@ impl<T: Tunnel> PendingTunnel<T> {
             (TunnelDirection::Inbound, MessageType::ShortTunnelBuild) => message.payload.to_vec(),
 
             // for outbound builds the reply can be received in `OutboundTunnelBuildReply`
-            (TunnelDirection::Outbound, MessageType::OutboundTunnelBuildReply) =>
-                message.payload.to_vec(),
+            (TunnelDirection::Outbound, MessageType::OutboundTunnelBuildReply) => {
+                message.payload.to_vec()
+            }
 
             // outbound reply can also be wrapped in a `GarlicMessage`
             (TunnelDirection::Outbound, MessageType::Garlic) => {
@@ -444,8 +445,9 @@ impl<T: Tunnel> PendingTunnel<T> {
                         }
                     )
                 }) {
-                    Some(GarlicMessageBlock::GarlicClove { message_body, .. }) =>
-                        message_body.to_vec(),
+                    Some(GarlicMessageBlock::GarlicClove { message_body, .. }) => {
+                        message_body.to_vec()
+                    }
                     _ => {
                         tracing::warn!(
                             target: LOG_TARGET,
@@ -570,7 +572,7 @@ impl<T: Tunnel> PendingTunnel<T> {
                 TunnelBuilder::new(self.name, self.tunnel_id, self.receiver),
                 |builder, hop| builder.with_hop(hop),
             )
-            .build::<R>())
+            .build())
     }
 
     /// Get reference to pending tunnel's hops.
@@ -856,14 +858,15 @@ mod test {
         };
 
         match pending_tunnel.try_build_tunnel::<MockRuntime>(message) {
-            Err(error) =>
+            Err(error) => {
                 for (i, (_, result)) in error.into_iter().enumerate() {
                     if i % 2 == 0 {
                         assert_eq!(result, Some(Err(TunnelError::TunnelRejected(30))));
                     } else {
                         assert_eq!(result, Some(Ok(())));
                     }
-                },
+                }
+            }
             _ => panic!("invalid result"),
         }
     }

--- a/emissary-core/src/tunnel/tests/mod.rs
+++ b/emissary-core/src/tunnel/tests/mod.rs
@@ -279,7 +279,11 @@ pub fn build_outbound_tunnel(
 pub fn build_inbound_tunnel(
     fast: bool,
     num_hops: usize,
-) -> (Bytes, InboundTunnel, Vec<TestTransitTunnelManager>) {
+) -> (
+    Bytes,
+    InboundTunnel<MockRuntime>,
+    Vec<TestTransitTunnelManager>,
+) {
     let (hops, mut transit_managers): (
         Vec<(Bytes, StaticPublicKey)>,
         Vec<TestTransitTunnelManager>,
@@ -304,20 +308,22 @@ pub fn build_inbound_tunnel(
     } = TunnelPoolBuildParameters::new(Default::default());
 
     let (pending_tunnel, next_router, message) =
-        PendingTunnel::<InboundTunnel>::create_tunnel::<MockRuntime>(TunnelBuildParameters {
-            hops: hops.clone(),
-            name: Str::from("tunnel-pool"),
-            noise: local_noise,
-            message_id,
-            tunnel_info: TunnelInfo::Inbound {
-                tunnel_id,
-                router_id: local_hash.clone(),
+        PendingTunnel::<InboundTunnel<MockRuntime>>::create_tunnel::<MockRuntime>(
+            TunnelBuildParameters {
+                hops: hops.clone(),
+                name: Str::from("tunnel-pool"),
+                noise: local_noise,
+                message_id,
+                tunnel_info: TunnelInfo::Inbound {
+                    tunnel_id,
+                    router_id: local_hash.clone(),
+                },
+                receiver: ReceiverKind::Inbound {
+                    message_rx: rx,
+                    handle,
+                },
             },
-            receiver: ReceiverKind::Inbound {
-                message_rx: rx,
-                handle,
-            },
-        })
+        )
         .unwrap();
 
     let message = match transit_managers[0].garlic().handle_message(message).unwrap().next() {

--- a/emissary-core/src/tunnel/transit/inbound.rs
+++ b/emissary-core/src/tunnel/transit/inbound.rs
@@ -327,20 +327,22 @@ mod tests {
         } = TunnelPoolBuildParameters::new(Default::default());
 
         let (pending, router_id, message) =
-            PendingTunnel::<InboundTunnel>::create_tunnel::<MockRuntime>(TunnelBuildParameters {
-                hops: vec![(ibgw_router_hash.clone(), ibgw_static_key.public())],
-                name: Str::from("tunnel-pool"),
-                noise: ibep_noise.clone(),
-                message_id: MessageId::from(MockRuntime::rng().next_u32()),
-                tunnel_info: TunnelInfo::Inbound {
-                    tunnel_id: TunnelId::random(),
-                    router_id: Bytes::from(RouterId::random().to_vec()),
+            PendingTunnel::<InboundTunnel<MockRuntime>>::create_tunnel::<MockRuntime>(
+                TunnelBuildParameters {
+                    hops: vec![(ibgw_router_hash.clone(), ibgw_static_key.public())],
+                    name: Str::from("tunnel-pool"),
+                    noise: ibep_noise.clone(),
+                    message_id: MessageId::from(MockRuntime::rng().next_u32()),
+                    tunnel_info: TunnelInfo::Inbound {
+                        tunnel_id: TunnelId::random(),
+                        router_id: Bytes::from(RouterId::random().to_vec()),
+                    },
+                    receiver: ReceiverKind::Inbound {
+                        message_rx: rx,
+                        handle,
+                    },
                 },
-                receiver: ReceiverKind::Inbound {
-                    message_rx: rx,
-                    handle,
-                },
-            })
+            )
             .unwrap();
 
         assert_eq!(router_id, ibgw_router_info.identity.id());
@@ -448,20 +450,22 @@ mod tests {
         } = TunnelPoolBuildParameters::new(Default::default());
 
         let (pending, router_id, message) =
-            PendingTunnel::<InboundTunnel>::create_tunnel::<MockRuntime>(TunnelBuildParameters {
-                hops: vec![(ibgw_router_hash.clone(), ibgw_static_key.public())],
-                name: Str::from("tunnel-pool"),
-                noise: ibep_noise.clone(),
-                message_id: MessageId::from(MockRuntime::rng().next_u32()),
-                tunnel_info: TunnelInfo::Inbound {
-                    tunnel_id: TunnelId::random(),
-                    router_id: Bytes::from(RouterId::random().to_vec()),
+            PendingTunnel::<InboundTunnel<MockRuntime>>::create_tunnel::<MockRuntime>(
+                TunnelBuildParameters {
+                    hops: vec![(ibgw_router_hash.clone(), ibgw_static_key.public())],
+                    name: Str::from("tunnel-pool"),
+                    noise: ibep_noise.clone(),
+                    message_id: MessageId::from(MockRuntime::rng().next_u32()),
+                    tunnel_info: TunnelInfo::Inbound {
+                        tunnel_id: TunnelId::random(),
+                        router_id: Bytes::from(RouterId::random().to_vec()),
+                    },
+                    receiver: ReceiverKind::Inbound {
+                        message_rx: rx,
+                        handle,
+                    },
                 },
-                receiver: ReceiverKind::Inbound {
-                    message_rx: rx,
-                    handle,
-                },
-            })
+            )
             .unwrap();
 
         assert_eq!(router_id, ibgw_router_info.identity.id());

--- a/emissary-core/src/tunnel/transit/outbound.rs
+++ b/emissary-core/src/tunnel/transit/outbound.rs
@@ -61,7 +61,7 @@ pub struct OutboundEndpoint<R: Runtime> {
     expiration_timer: BoxFuture<'static, ()>,
 
     /// Fragment handler.
-    fragment: FragmentHandler,
+    fragment: FragmentHandler<R>,
 
     /// Used bandwidth.
     bandwidth: usize,
@@ -382,6 +382,11 @@ impl<R: Runtime> Future for OutboundEndpoint<R> {
         if self.expiration_timer.poll_unpin(cx).is_ready() {
             return Poll::Ready(self.tunnel_id);
         }
+
+        // poll fragment handler
+        //
+        // the futures don't return anything but must be polled so they make progress
+        let _ = self.fragment.poll_unpin(cx);
 
         Poll::Pending
     }


### PR DESCRIPTION
This PR aims to close https://github.com/altonen/emissary/issues/17.

A few uncertainties before the PR is ready:
* Because the tunnel `FragmentHandler` is functionally identical to the SSU2 `FragmentHandler`, is there anything preventing them from merging into one?
* I am unsure which timing to use: the expiration from https://github.com/i2p/i2p.i2p/blob/master/router/java/src/net/i2p/data/i2np/TunnelDataMessage.java or https://github.com/i2p/i2p.i2p/blob/master/router/java/src/net/i2p/router/tunnel/FragmentHandler.java (or neither?)
* The `config::tests::config_update_works` and `config::tests::fresh_boot_directory_created` test cases are failing, but I don't think that's because of this PR