### PR TITLE
Implement a `HashMap` backend for `Mapping`

### DIFF
--- a/emissary-core/src/i2cp/pending.rs
+++ b/emissary-core/src/i2cp/pending.rs
@@ -33,7 +33,7 @@ use crate::{
         },
         socket::I2cpSocket,
     },
-    primitives::{Date, DestinationId, Lease, Str, TunnelId},
+    primitives::{Date, DestinationId, Lease, Mapping, Str, TunnelId},
     profile::ProfileStorage,
     runtime::{AddressBook, Runtime},
     tunnel::{TunnelManagerHandle, TunnelPoolConfig, TunnelPoolEvent, TunnelPoolHandle},
@@ -71,7 +71,7 @@ pub struct I2cpSessionContext<R: Runtime> {
     pub leaseset: Bytes,
 
     /// Session options.
-    pub options: HashMap<Str, Str>,
+    pub options: Mapping,
 
     /// Active outbound tunnels.
     pub outbound: HashSet<TunnelId>,
@@ -113,7 +113,7 @@ enum PendingSessionState<R: Runtime> {
         socket: I2cpSocket<R>,
 
         /// Session options.
-        options: HashMap<Str, Str>,
+        options: Mapping,
 
         /// Tunnel pool build future.
         ///
@@ -134,7 +134,7 @@ enum PendingSessionState<R: Runtime> {
         socket: I2cpSocket<R>,
 
         /// Session options.
-        options: HashMap<Str, Str>,
+        options: Mapping,
 
         /// Handle to the built tunnel pool.
         handle: TunnelPoolHandle,
@@ -158,7 +158,7 @@ enum PendingSessionState<R: Runtime> {
         socket: I2cpSocket<R>,
 
         /// Session options.
-        options: HashMap<Str, Str>,
+        options: Mapping,
 
         /// Handle to the built tunnel pool.
         handle: TunnelPoolHandle,

--- a/emissary-core/src/i2cp/session.rs
+++ b/emissary-core/src/i2cp/session.rs
@@ -29,7 +29,7 @@ use crate::{
         socket::I2cpSocket,
     },
     netdb::NetDbHandle,
-    primitives::{Date, DestinationId, Str},
+    primitives::{Date, DestinationId, Mapping, Str},
     runtime::{AddressBook, JoinSet, Runtime},
 };
 
@@ -80,7 +80,7 @@ pub struct I2cpSession<R: Runtime> {
 
     /// Session options.
     #[allow(unused)]
-    options: HashMap<Str, Str>,
+    options: Mapping,
 
     /// Pending outbound connections.
     pending_connections: HashMap<DestinationId, VecDeque<PendingMessage>>,
@@ -121,7 +121,7 @@ impl<R: Runtime> I2cpSession<R> {
         );
 
         // TODO: remove
-        for (key, value) in &options {
+        for (key, value) in options.iter() {
             tracing::info!("{key}={value}");
         }
 
@@ -377,7 +377,7 @@ impl<R: Runtime> I2cpSession<R> {
                             }]),
                         );
                     }
-                    LeaseSetStatus::Pending =>
+                    LeaseSetStatus::Pending => {
                         match self.pending_connections.get_mut(&destination_id) {
                             Some(messages) => messages.push_back(PendingMessage {
                                 parameters: I2cpParameters {
@@ -397,7 +397,8 @@ impl<R: Runtime> I2cpSession<R> {
                                 );
                                 // debug_assert!(false);
                             }
-                        },
+                        }
+                    }
                 }
             }
             _ => {}

--- a/emissary-core/src/i2np/tunnel/build/short.rs
+++ b/emissary-core/src/i2np/tunnel/build/short.rs
@@ -186,7 +186,7 @@ impl TunnelBuildRecord {
         let (rest, _request_time) = be_u32(rest)?;
         let (rest, _request_expiration) = be_u32(rest)?;
         let (rest, next_message_id) = be_u32(rest)?;
-        let (rest, _options) = Mapping::parse_multi_frame(rest)?;
+        let (rest, _options) = Mapping::parse_frame(rest)?;
         let (rest, _padding) = take(rest.len())(rest)?;
         let role = HopRole::from_u8(flags).ok_or(Err::Error(make_error(input, ErrorKind::Fail)))?;
 
@@ -236,8 +236,6 @@ impl TunnelBuildRecord {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::primitives::Str;
-    use core::str::FromStr;
 
     #[test]
     fn all_zero_bytes() {
@@ -295,16 +293,13 @@ mod tests {
         out.put_u32(0u32);
 
         {
-            let option1 = Mapping::new(
-                Str::from_str("hello").unwrap(),
-                Str::from_str("world").unwrap(),
-            )
-            .serialize();
-            let option2 = Mapping::new(
-                Str::from_str("goodbye").unwrap(),
-                Str::from_str("world").unwrap(),
-            )
-            .serialize();
+            let mut option1 = Mapping::new();
+            option1.insert("hello".into(), "world".into());
+            let option1 = option1.serialize();
+
+            let mut option2 = Mapping::new();
+            option2.insert("goodbye".into(), "world".into());
+            let option2 = option2.serialize();
 
             out.put_u16((option1.len() + option2.len()) as u16);
             out.put_slice(&option1);

--- a/emissary-core/src/i2np/tunnel/build/short.rs
+++ b/emissary-core/src/i2np/tunnel/build/short.rs
@@ -293,11 +293,11 @@ mod tests {
         out.put_u32(0u32);
 
         {
-            let mut option1 = Mapping::new();
+            let mut option1 = Mapping::default();
             option1.insert("hello".into(), "world".into());
             let option1 = option1.serialize();
 
-            let mut option2 = Mapping::new();
+            let mut option2 = Mapping::default();
             option2.insert("goodbye".into(), "world".into());
             let option2 = option2.serialize();
 

--- a/emissary-core/src/i2np/tunnel/build/variable.rs
+++ b/emissary-core/src/i2np/tunnel/build/variable.rs
@@ -72,7 +72,7 @@ impl<'a> TunnelBuildRecord<'a> {
         let (rest, _request_time) = be_u32(rest)?;
         let (rest, _request_expiration) = be_u32(rest)?;
         let (rest, next_message_id) = be_u32(rest)?;
-        let (rest, _options) = Mapping::parse_multi_frame(rest)?;
+        let (rest, _options) = Mapping::parse_frame(rest)?;
         let (rest, _padding) = take(input.len() - rest.len())(rest)?;
         let role = HopRole::from_u8(flags).ok_or(Err::Error(make_error(input, ErrorKind::Fail)))?;
 

--- a/emissary-core/src/netdb/mod.rs
+++ b/emissary-core/src/netdb/mod.rs
@@ -2018,8 +2018,9 @@ mod tests {
         events::EventManager,
         i2np::database::lookup::DatabaseLookupBuilder,
         primitives::{
-            Capabilities, Date, Destination, DestinationId, Lease, LeaseSet2Header, RouterAddress,
-            RouterIdentity, RouterInfo, RouterInfoBuilder, Str, TransportKind, TunnelId,
+            Capabilities, Date, Destination, DestinationId, Lease, LeaseSet2Header, Mapping,
+            RouterAddress, RouterIdentity, RouterInfo, RouterInfoBuilder, Str, TransportKind,
+            TunnelId,
         },
         runtime::mock::MockRuntime,
         subsystem::{InnerSubsystemEvent, SubsystemCommand},
@@ -2693,7 +2694,7 @@ mod tests {
                                 TransportKind::Ntcp2,
                                 RouterAddress::new_unpublished_ntcp2([1u8; 32], 8888),
                             )]),
-                            options: HashMap::from_iter([
+                            options: Mapping::from_iter([
                                 (Str::from("netId"), Str::from("2")),
                                 (Str::from("caps"), Str::from("L")),
                             ]),
@@ -2802,7 +2803,7 @@ mod tests {
                                 TransportKind::Ntcp2,
                                 RouterAddress::new_unpublished_ntcp2([1u8; 32], 8888),
                             )]),
-                            options: HashMap::from_iter([
+                            options: Mapping::from_iter([
                                 (Str::from("netId"), Str::from("2")),
                                 (Str::from("caps"), Str::from("L")),
                             ]),
@@ -3102,7 +3103,7 @@ mod tests {
                                 TransportKind::Ntcp2,
                                 RouterAddress::new_unpublished_ntcp2([1u8; 32], 8888),
                             )]),
-                            options: HashMap::from_iter([
+                            options: Mapping::from_iter([
                                 (Str::from("netId"), Str::from("2")),
                                 (Str::from("caps"), Str::from("L")),
                             ]),
@@ -3631,7 +3632,7 @@ mod tests {
                                 TransportKind::Ntcp2,
                                 RouterAddress::new_unpublished_ntcp2([1u8; 32], 8888),
                             )]),
-                            options: HashMap::from_iter([
+                            options: Mapping::from_iter([
                                 (Str::from("netId"), Str::from("2")),
                                 (Str::from("caps"), Str::from("L")),
                             ]),
@@ -3664,7 +3665,7 @@ mod tests {
                                 TransportKind::Ntcp2,
                                 RouterAddress::new_unpublished_ntcp2([1u8; 32], 8888),
                             )]),
-                            options: HashMap::from_iter([
+                            options: Mapping::from_iter([
                                 (Str::from("netId"), Str::from("2")),
                                 (Str::from("caps"), Str::from("L")),
                             ]),
@@ -3880,7 +3881,7 @@ mod tests {
                                 TransportKind::Ntcp2,
                                 RouterAddress::new_unpublished_ntcp2([1u8; 32], 8888),
                             )]),
-                            options: HashMap::from_iter([
+                            options: Mapping::from_iter([
                                 (Str::from("netId"), Str::from("99")),
                                 (Str::from("caps"), Str::from("L")),
                             ]),
@@ -4059,7 +4060,7 @@ mod tests {
                                 TransportKind::Ntcp2,
                                 RouterAddress::new_unpublished_ntcp2([1u8; 32], 8888),
                             )]),
-                            options: HashMap::from_iter([
+                            options: Mapping::from_iter([
                                 (Str::from("netId"), Str::from("2")),
                                 (Str::from("caps"), Str::from("L")),
                             ]),

--- a/emissary-core/src/primitives/lease_set.rs
+++ b/emissary-core/src/primitives/lease_set.rs
@@ -261,7 +261,7 @@ impl LeaseSet2 {
     /// Returns the parsed message and rest of `input` on success.
     pub fn parse_frame(input: &[u8]) -> IResult<&[u8], Self> {
         let (rest, header) = LeaseSet2Header::parse_frame(input)?;
-        let (rest, _) = Mapping::parse_multi_frame(rest)?;
+        let (rest, _) = Mapping::parse_frame(rest)?;
         let (rest, num_key_types) = be_u8(rest)?;
 
         let (rest, public_keys) = (0..num_key_types)

--- a/emissary-core/src/primitives/mapping.rs
+++ b/emissary-core/src/primitives/mapping.rs
@@ -167,7 +167,7 @@ mod tests {
         let mut mapping = Mapping::default();
         mapping.insert("hello".into(), "world".into());
 
-        let mut ser = mapping.serialize();
+        let mut ser = mapping.serialize().to_vec();
         ser.push(1);
         ser.push(2);
         ser.push(3);
@@ -181,7 +181,7 @@ mod tests {
         let mut mapping = Mapping::default();
         mapping.insert("hello".into(), "world".into());
 
-        let mut ser = mapping.serialize();
+        let mut ser = mapping.serialize().to_vec();
         ser.push(1);
         ser.push(2);
         ser.push(3);
@@ -216,7 +216,7 @@ mod tests {
         assert_eq!(mapping.get(&"e".into()), Some(&Str::from("f")));
         assert_eq!(mapping.get(&"zz".into()), Some(&Str::from("z")));
 
-        assert_eq!(mapping.serialize(), expected_ser);
+        assert_eq!(mapping.serialize().to_vec(), expected_ser);
     }
 
     #[test]

--- a/emissary-core/src/primitives/mapping.rs
+++ b/emissary-core/src/primitives/mapping.rs
@@ -18,82 +18,91 @@
 
 use crate::primitives::Str;
 
-use hashbrown::HashMap;
+use bytes::{BufMut, BytesMut};
+use hashbrown::{
+    hash_map::{IntoIter, Iter},
+    HashMap,
+};
 use nom::{
     number::complete::{be_u16, be_u8},
     IResult,
 };
 
-use alloc::{vec, vec::Vec};
-use core::fmt;
+use alloc::vec::Vec;
+use core::{
+    fmt::{self, Debug},
+    num::NonZeroUsize,
+};
 
 /// Key-value mapping
-#[derive(Debug, PartialEq, Eq)]
-pub struct Mapping {
-    /// Key
-    key: Str,
-
-    /// Value.
-    value: Str,
-}
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Mapping(HashMap<Str, Str>);
 
 impl fmt::Display for Mapping {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}={}", self.key, self.value)
+        self.0.fmt(f)
     }
 }
 
 impl Mapping {
     /// Create new [`Mapping`].
-    pub fn new(key: Str, value: Str) -> Self {
-        Self { key, value }
+    pub fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    pub fn from_iter(iter: impl IntoIterator<Item = (Str, Str)>) -> Self {
+        Self(HashMap::from_iter(iter))
     }
 
     /// Serialize [`Mapping`] into a byte vector.
-    pub fn serialize(self) -> Vec<u8> {
-        let key = self.key.serialize();
-        let value = self.value.serialize();
+    pub fn serialize(&self) -> Vec<u8> {
+        // Allocate at least two bytes for the size prefix
+        let mut out = BytesMut::with_capacity(2);
+        let mut data = out.split_off(2);
 
-        // key length + value length + length field + `=` + `;`
-        let size = key.len() + value.len() + 2;
-        let mut out = vec![0u8; size];
+        let mut entries: Vec<_> = self.0.iter().collect();
 
-        out[..key.len()].copy_from_slice(&key);
-        out[key.len()] = b'=';
-        out[1 + key.len()..1 + key.len() + value.len()].copy_from_slice(&value);
-        out[1 + key.len() + value.len()] = b';';
+        // Our mapping implementation does not support duplicate keys, so we do not need to preserve
+        // order
+        entries.sort_unstable_by(|a, b| a.0.cmp(b.0));
+        for (key, value) in entries {
+            let key = key.serialize();
+            let value = value.serialize();
+            data.reserve(key.len() + value.len() + 2);
+            data.extend(key);
+            data.put_u8(b'=');
+            data.extend(value);
+            data.put_u8(b';');
+        }
+        //TODO: validate that this is less than u16::MAX?
+        out.put_u16(data.len() as u16);
+        out.unsplit(data);
 
-        out
+        //TODO: Work with `Bytes` instead of `Vec<u8>` to avoid copying data?
+        out.freeze().to_vec()
     }
 
-    /// Parse [`Mapping`] from `input`, returning rest of `input` and parsed address.
-    pub fn parse_frame(input: &[u8]) -> IResult<&[u8], Mapping> {
-        let (rest, key) = Str::parse_frame(input)?;
-        let (rest, _) = be_u8(rest)?; // ignore `=`
-        let (rest, value) = Str::parse_frame(rest)?;
-        let (rest, _) = be_u8(rest)?; // ignore `;`
+    /// Parse [`Mapping`] from `input`, returning rest of `input` and parsed mapping.
+    pub fn parse_frame(input: &[u8]) -> IResult<&[u8], Self> {
+        let (rest, size) = be_u16(input)?;
+        let mut mapping = Self::new();
 
-        Ok((rest, Mapping { key, value }))
-    }
+        if let Some((mut data, rest)) = rest.split_at_checked(size as usize) {
+            while !data.is_empty() {
+                let (remaining, key) = Str::parse_frame(data)?;
+                let (remaining, _) = be_u8(remaining)?; // Should we validate '='?
+                let (remaining, value) = Str::parse_frame(remaining)?;
+                let (remaining, _) = be_u8(remaining)?; // Should we validate ';'?
+                mapping.insert(key, value);
+                data = remaining;
+            }
 
-    /// Parse multiple [`Mapping`]s from `input`.
-    pub fn parse_multi_frame(input: &[u8]) -> IResult<&[u8], Vec<Mapping>> {
-        if input.is_empty() {
-            return Ok((&[], Vec::new()));
+            Ok((rest, mapping))
+        } else {
+            // This is safe as the zero case will always pass `split_at_checked`
+            let non_zero_size = NonZeroUsize::new(size as usize).unwrap();
+            Err(nom::Err::Incomplete(nom::Needed::Size(non_zero_size)))
         }
-
-        let (mut rest, mut num_option_bytes) = be_u16(input)?;
-        let mut options = Vec::<Mapping>::new();
-
-        while num_option_bytes > 0 {
-            let (_rest, mapping) = Mapping::parse_frame(rest)?;
-            rest = _rest;
-
-            num_option_bytes = num_option_bytes.saturating_sub(mapping.serialized_len() as u16);
-            options.push(mapping);
-        }
-
-        Ok((rest, options))
     }
 
     /// Try to convert `bytes` into a [`Mapping`].
@@ -101,19 +110,32 @@ impl Mapping {
         Some(Self::parse_frame(bytes.as_ref()).ok()?.1)
     }
 
-    /// Get reference to inner key-value mapping.
-    pub fn mapping(&self) -> (&Str, &Str) {
-        (&self.key, &self.value)
+    /// Equivalent to `HashMap::insert`
+    pub fn insert(&mut self, key: Str, value: Str) -> Option<Str> {
+        self.0.insert(key, value)
     }
 
-    /// Get serialized length of [`Mapping`].
-    pub fn serialized_len(&self) -> usize {
-        self.key.serialized_len() + self.value.serialized_len() + 2
+    /// Equivalent to `HashMap::get`
+    pub fn get(&self, key: &Str) -> Option<&Str> {
+        self.0.get(key)
     }
 
-    /// Convert a vector of [`Mapping`]s into a hashmap.
-    pub fn into_hashmap(mappings: Vec<Mapping>) -> HashMap<Str, Str> {
-        mappings.into_iter().map(|mapping| (mapping.key, mapping.value)).collect()
+    /// Equivalent to `HashMap::len`
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn iter(&self) -> Iter<'_, Str, Str> {
+        self.0.iter()
+    }
+}
+
+impl IntoIterator for Mapping {
+    type Item = (Str, Str);
+    type IntoIter = IntoIter<Str, Str>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }
 
@@ -123,135 +145,79 @@ mod tests {
 
     #[test]
     fn empty_mapping() {
-        assert!(Str::parse(Vec::new()).is_none());
+        assert_eq!(Mapping::parse(b"\0\0"), Some(Mapping::new()));
     }
 
     #[test]
     fn valid_mapping() {
-        let mapping = Mapping::new(Str::from("hello"), Str::from("world")).serialize();
+        let mut mapping = Mapping::new();
+        mapping.insert("hello".into(), "world".into());
 
-        assert_eq!(
-            Mapping::parse(mapping),
-            Some(Mapping {
-                key: Str::from("hello"),
-                value: Str::from("world"),
-            })
-        );
+        let ser = mapping.serialize();
+
+        assert_eq!(Mapping::parse(ser), Some(mapping));
     }
 
     #[test]
     fn valid_string_with_extra_bytes() {
-        let mut mapping = Mapping::new(Str::from("hello"), Str::from("world")).serialize();
-        mapping.push(1);
-        mapping.push(2);
-        mapping.push(3);
-        mapping.push(4);
+        let mut mapping = Mapping::new();
+        mapping.insert("hello".into(), "world".into());
 
-        assert_eq!(
-            Mapping::parse(mapping),
-            Some(Mapping {
-                key: Str::from("hello"),
-                value: Str::from("world"),
-            })
-        );
+        let mut ser = mapping.serialize();
+        ser.push(1);
+        ser.push(2);
+        ser.push(3);
+        ser.push(4);
+
+        assert_eq!(Mapping::parse(ser), Some(mapping));
     }
 
     #[test]
     fn extra_bytes_returned() {
-        let mut mapping = Mapping::new(Str::from("hello"), Str::from("world")).serialize();
-        mapping.push(1);
-        mapping.push(2);
-        mapping.push(3);
-        mapping.push(4);
+        let mut mapping = Mapping::new();
+        mapping.insert("hello".into(), "world".into());
 
-        let (rest, mapping) = Mapping::parse_frame(&mapping).unwrap();
+        let mut ser = mapping.serialize();
+        ser.push(1);
+        ser.push(2);
+        ser.push(3);
+        ser.push(4);
 
-        assert_eq!(
-            mapping,
-            Mapping {
-                key: Str::from("hello"),
-                value: Str::from("world"),
-            }
-        );
+        let (rest, parsed_mapping) = Mapping::parse_frame(&ser).unwrap();
+
+        assert_eq!(parsed_mapping, mapping);
         assert_eq!(rest, [1, 2, 3, 4]);
     }
 
     #[test]
     fn multiple_mappings() {
-        let mut mapping1 = Mapping::new(Str::from("hello"), Str::from("world")).serialize();
-        let mapping2 = Mapping::new(Str::from("foo"), Str::from("bar")).serialize();
-        let mapping3 = Mapping::new(Str::from("siip"), Str::from("huup")).serialize();
+        let expected_ser = b"\x00\x19\x01a=\x01b;\x01c=\x01d;\x01e=\x01f;\x02zz=\x01z;";
 
-        mapping1.extend_from_slice(&mapping2);
-        mapping1.extend_from_slice(&mapping3);
+        let mapping = Mapping::parse(expected_ser).expect("to be valid");
 
-        let (rest, mapping) = Mapping::parse_frame(&mapping1).unwrap();
-        assert_eq!(
-            mapping,
-            Mapping {
-                key: Str::from("hello"),
-                value: Str::from("world"),
-            }
+        let keys: Vec<_> = mapping.0.keys().collect();
+        // Check that the keys aren't already ordered
+        assert_ne!(
+            keys,
+            [
+                &Str::from("a"),
+                &Str::from("c"),
+                &Str::from("e"),
+                &Str::from("zz")
+            ]
         );
 
-        let (rest, mapping) = Mapping::parse_frame(rest).unwrap();
-        assert_eq!(
-            mapping,
-            Mapping {
-                key: Str::from("foo"),
-                value: Str::from("bar"),
-            }
-        );
+        assert_eq!(mapping.get(&"a".into()), Some(&Str::from("b")));
+        assert_eq!(mapping.get(&"c".into()), Some(&Str::from("d")));
+        assert_eq!(mapping.get(&"e".into()), Some(&Str::from("f")));
+        assert_eq!(mapping.get(&"zz".into()), Some(&Str::from("z")));
 
-        let (_rest, mapping) = Mapping::parse_frame(rest).unwrap();
-        assert_eq!(
-            mapping,
-            Mapping {
-                key: Str::from("siip"),
-                value: Str::from("huup"),
-            }
-        );
+        assert_eq!(mapping.serialize(), expected_ser);
     }
 
     #[test]
-    fn parse_multi_frame() {
-        let mapping1 = Mapping::new(Str::from("hello"), Str::from("world")).serialize();
-        let mapping2 = Mapping::new(Str::from("foo"), Str::from("bar")).serialize();
-        let mapping3 = Mapping::new(Str::from("siip"), Str::from("huup")).serialize();
-
-        let mut mappings = ((mapping1.len() + mapping2.len() + mapping3.len()) as u16)
-            .to_be_bytes()
-            .to_vec();
-
-        mappings.extend_from_slice(&mapping1);
-        mappings.extend_from_slice(&mapping2);
-        mappings.extend_from_slice(&mapping3);
-
-        let (rest, mappings) = Mapping::parse_multi_frame(&mappings).unwrap();
-
-        assert!(rest.is_empty());
-        assert_eq!(mappings.len(), 3);
-
-        assert_eq!(
-            mappings[0],
-            Mapping {
-                key: Str::from("hello"),
-                value: Str::from("world"),
-            }
-        );
-        assert_eq!(
-            mappings[1],
-            Mapping {
-                key: Str::from("foo"),
-                value: Str::from("bar"),
-            }
-        );
-        assert_eq!(
-            mappings[2],
-            Mapping {
-                key: Str::from("siip"),
-                value: Str::from("huup"),
-            }
-        );
+    fn over_sized() {
+        let ser = b"\x01\x00\x01a=\x01b;\x01c=\x01d;\x01e=\x01f;";
+        assert!(Mapping::parse(ser).is_none());
     }
 }

--- a/emissary-core/src/primitives/router_address.rs
+++ b/emissary-core/src/primitives/router_address.rs
@@ -95,7 +95,7 @@ impl RouterAddress {
         let static_key = StaticPrivateKey::from(key).public();
         let key = base64_encode(&static_key);
 
-        let mut options = Mapping::new();
+        let mut options = Mapping::default();
         options.insert("v".into(), "2".into());
         options.insert("s".into(), key.into());
 
@@ -112,7 +112,7 @@ impl RouterAddress {
     pub fn new_published_ntcp2(key: [u8; 32], iv: [u8; 16], port: u16, host: Ipv4Addr) -> Self {
         let static_key = StaticPrivateKey::from(key).public();
 
-        let mut options = Mapping::new();
+        let mut options = Mapping::default();
         options.insert(Str::from("v"), Str::from("2"));
         options.insert(Str::from("s"), Str::from(base64_encode(&static_key)));
         options.insert(Str::from("host"), Str::from(host.to_string()));
@@ -136,7 +136,7 @@ impl RouterAddress {
         };
         let intro_key = base64_encode(intro_key);
 
-        let mut options = Mapping::new();
+        let mut options = Mapping::default();
         options.insert(Str::from_str("v").unwrap(), Str::from_str("2").unwrap());
         options.insert(
             Str::from_str("s").unwrap(),
@@ -169,7 +169,7 @@ impl RouterAddress {
         };
         let intro_key = base64_encode(intro_key);
 
-        let mut options = Mapping::new();
+        let mut options = Mapping::default();
         options.insert(Str::from("v"), Str::from("2"));
         options.insert(
             Str::from_str("s").unwrap(),

--- a/emissary-core/src/primitives/router_address.rs
+++ b/emissary-core/src/primitives/router_address.rs
@@ -22,7 +22,6 @@ use crate::{
 };
 
 use bytes::{BufMut, BytesMut};
-use hashbrown::HashMap;
 use nom::{
     error::{make_error, ErrorKind},
     number::complete::be_u8,
@@ -84,7 +83,7 @@ pub struct RouterAddress {
     pub transport: TransportKind,
 
     /// Options.
-    pub options: HashMap<Str, Str>,
+    pub options: Mapping,
 
     /// Router's socket address.
     pub socket_address: Option<SocketAddr>,
@@ -96,9 +95,9 @@ impl RouterAddress {
         let static_key = StaticPrivateKey::from(key).public();
         let key = base64_encode(&static_key);
 
-        let mut options = HashMap::<Str, Str>::new();
-        options.insert(Str::from_str("v").unwrap(), Str::from_str("2").unwrap());
-        options.insert(Str::from_str("s").unwrap(), Str::from_str(&key).unwrap());
+        let mut options = Mapping::new();
+        options.insert("v".into(), "2".into());
+        options.insert("s".into(), key.into());
 
         Self {
             cost: 14,
@@ -113,7 +112,7 @@ impl RouterAddress {
     pub fn new_published_ntcp2(key: [u8; 32], iv: [u8; 16], port: u16, host: Ipv4Addr) -> Self {
         let static_key = StaticPrivateKey::from(key).public();
 
-        let mut options = HashMap::<Str, Str>::new();
+        let mut options = Mapping::new();
         options.insert(Str::from("v"), Str::from("2"));
         options.insert(Str::from("s"), Str::from(base64_encode(&static_key)));
         options.insert(Str::from("host"), Str::from(host.to_string()));
@@ -137,7 +136,7 @@ impl RouterAddress {
         };
         let intro_key = base64_encode(intro_key);
 
-        let mut options = HashMap::<Str, Str>::new();
+        let mut options = Mapping::new();
         options.insert(Str::from_str("v").unwrap(), Str::from_str("2").unwrap());
         options.insert(
             Str::from_str("s").unwrap(),
@@ -170,7 +169,7 @@ impl RouterAddress {
         };
         let intro_key = base64_encode(intro_key);
 
-        let mut options = HashMap::<Str, Str>::new();
+        let mut options = Mapping::new();
         options.insert(Str::from("v"), Str::from("2"));
         options.insert(
             Str::from_str("s").unwrap(),
@@ -197,8 +196,7 @@ impl RouterAddress {
         let (rest, cost) = be_u8(input)?;
         let (rest, expires) = Date::parse_frame(rest)?;
         let (rest, transport) = Str::parse_frame(rest)?;
-        let (rest, options) = Mapping::parse_multi_frame(rest)?;
-        let options = Mapping::into_hashmap(options);
+        let (rest, options) = Mapping::parse_frame(rest)?;
         let socket_address: Option<SocketAddr> = {
             let maybe_host = options.get(&Str::from("host"));
             let maybe_port = options.get(&Str::from("port"));
@@ -237,23 +235,13 @@ impl RouterAddress {
 
     /// Serialize [`RouterAddress`].
     pub fn serialize(&self) -> BytesMut {
-        let options = {
-            let mut options = self.options.clone().into_iter().collect::<Vec<_>>();
-            options.sort_by(|a, b| a.0.cmp(&b.0));
-
-            options
-                .into_iter()
-                .flat_map(|(key, value)| Mapping::new(key, value).serialize())
-                .collect::<Vec<_>>()
-        };
-
+        let options = self.options.serialize();
         let transport = self.transport.serialize();
-        let mut out = BytesMut::with_capacity(1 + 8 + transport.len() + options.len() + 2);
+        let mut out = BytesMut::with_capacity(1 + 8 + transport.len() + options.len());
 
         out.put_u8(self.cost);
         out.put_slice(&self.expires.serialize());
         out.put_slice(&transport);
-        out.put_u16(options.len() as u16);
         out.put_slice(&options);
 
         out

--- a/emissary-core/src/primitives/router_info.rs
+++ b/emissary-core/src/primitives/router_info.rs
@@ -89,7 +89,7 @@ impl RouterInfo {
             Some(router_info) => RouterIdentity::parse(router_info).expect("to succeed"),
         };
 
-        let mut options = Mapping::new();
+        let mut options = Mapping::default();
         options.insert(
             Str::from("netId"),
             config
@@ -506,7 +506,7 @@ impl RouterInfoBuilder {
             ));
         }
 
-        let mut options = Mapping::new();
+        let mut options = Mapping::default();
         options.insert("netId".into(), "2".into());
         options.insert("router.version".into(), "0.9.62".into());
 

--- a/emissary-core/src/primitives/router_info.rs
+++ b/emissary-core/src/primitives/router_info.rs
@@ -34,7 +34,7 @@ use nom::{
     Err, IResult,
 };
 
-use alloc::{string::ToString, vec, vec::Vec};
+use alloc::{string::ToString, vec::Vec};
 
 /// Signature length.
 const SIGNATURE_LEN: usize = 64usize;
@@ -55,7 +55,7 @@ pub struct RouterInfo {
     pub net_id: u8,
 
     /// Router options.
-    pub options: HashMap<Str, Str>,
+    pub options: Mapping,
 
     /// When the router info was published.
     pub published: Date,
@@ -89,7 +89,8 @@ impl RouterInfo {
             Some(router_info) => RouterIdentity::parse(router_info).expect("to succeed"),
         };
 
-        let net_id = Mapping::new(
+        let mut options = Mapping::new();
+        options.insert(
             Str::from("netId"),
             config
                 .net_id
@@ -107,9 +108,8 @@ impl RouterInfo {
             },
         };
 
-        let router_version = Mapping::new(Str::from("router.version"), Str::from("0.9.62"));
-        let caps_mapping = Mapping::new(Str::from("caps"), caps.clone());
-        let options = Mapping::into_hashmap(vec![net_id, caps_mapping, router_version]);
+        options.insert(Str::from("router.version"), Str::from("0.9.62"));
+        options.insert(Str::from("caps"), caps.clone());
 
         RouterInfo {
             addresses: {
@@ -167,8 +167,7 @@ impl RouterInfo {
 
         // ignore `peer_size`
         let (rest, _) = be_u8(rest)?;
-        let (rest, options) = Mapping::parse_multi_frame(rest)?;
-        let options = Mapping::into_hashmap(options);
+        let (rest, options) = Mapping::parse_frame(rest)?;
 
         let capabilities = match options.get(&Str::from("caps")) {
             None => {
@@ -246,15 +245,7 @@ impl RouterInfo {
             self.addresses.get(&TransportKind::Ntcp2).map(|address| address.serialize());
         let maybe_ssu2 =
             self.addresses.get(&TransportKind::Ssu2).map(|address| address.serialize());
-        let options = {
-            let mut options = self.options.clone().into_iter().collect::<Vec<_>>();
-            options.sort_by(|a, b| a.0.cmp(&b.0));
-
-            options
-                .into_iter()
-                .flat_map(|(key, value)| Mapping::new(key, value).serialize())
-                .collect::<Vec<_>>()
-        };
+        let options = self.options.serialize();
 
         let size = identity
             .len()
@@ -264,7 +255,6 @@ impl RouterInfo {
             .saturating_add(maybe_ssu2.as_ref().map_or(0usize, |address| address.len()))
             .saturating_add(options.len())
             .saturating_add(1usize) // psize
-            .saturating_add(2usize) // field for options size
             .saturating_add(64usize); // signature
 
         let mut out = BytesMut::with_capacity(size);
@@ -286,7 +276,6 @@ impl RouterInfo {
         }
 
         out.put_u8(0u8); // psize
-        out.put_u16(options.len() as u16);
         out.put_slice(&options);
 
         let signature = signing_key.sign(&out[..size - 64]);
@@ -517,10 +506,9 @@ impl RouterInfoBuilder {
             ));
         }
 
-        let mut options = Mapping::into_hashmap(vec![
-            Mapping::new(Str::from("netId"), Str::from("2")),
-            Mapping::new(Str::from("router.version"), Str::from("0.9.62")),
-        ]);
+        let mut options = Mapping::new();
+        options.insert("netId".into(), "2".into());
+        options.insert("router.version".into(), "0.9.62".into());
 
         let capabilities = if self.floodfill {
             options.insert(Str::from("caps"), Str::from("XfR"));
@@ -721,7 +709,7 @@ mod tests {
                     "127.0.0.1".parse().unwrap(),
                 ),
             )]),
-            options: HashMap::from_iter([(Str::from("caps"), Str::from("L"))]),
+            options: Mapping::from_iter([(Str::from("caps"), Str::from("L"))]),
             net_id: 2,
             capabilities: Capabilities::parse(&Str::from("L")).unwrap(),
         }
@@ -748,7 +736,7 @@ mod tests {
                     "127.0.0.1".parse().unwrap(),
                 ),
             )]),
-            options: HashMap::from_iter([(Str::from("netId"), Str::from("2"))]),
+            options: Mapping::from_iter([(Str::from("netId"), Str::from("2"))]),
             net_id: 2,
             capabilities: Capabilities::parse(&Str::from("L")).unwrap(),
         }
@@ -775,7 +763,7 @@ mod tests {
                     "127.0.0.1".parse().unwrap(),
                 ),
             )]),
-            options: HashMap::from_iter([
+            options: Mapping::from_iter([
                 (Str::from("netId"), Str::from("2")),
                 (Str::from("caps"), Str::from("HL")),
             ]),
@@ -800,7 +788,7 @@ mod tests {
                 TransportKind::Ntcp2,
                 RouterAddress::new_unpublished_ntcp2([1u8; 32], 8888),
             )]),
-            options: HashMap::from_iter([
+            options: Mapping::from_iter([
                 (Str::from("netId"), Str::from("2")),
                 (Str::from("caps"), Str::from("UL")),
             ]),
@@ -825,7 +813,7 @@ mod tests {
                 TransportKind::Ntcp2,
                 RouterAddress::new_unpublished_ntcp2([1u8; 32], 8888),
             )]),
-            options: HashMap::from_iter([
+            options: Mapping::from_iter([
                 (Str::from("netId"), Str::from("2")),
                 (Str::from("caps"), Str::from("LR")),
             ]),
@@ -855,7 +843,7 @@ mod tests {
                     "127.0.0.1".parse().unwrap(),
                 ),
             )]),
-            options: HashMap::from_iter([
+            options: Mapping::from_iter([
                 (Str::from("netId"), Str::from("2")),
                 (Str::from("caps"), Str::from("LR")),
             ]),
@@ -886,7 +874,7 @@ mod tests {
                     "127.0.0.1".parse().unwrap(),
                 ),
             )]),
-            options: HashMap::from_iter([
+            options: Mapping::from_iter([
                 (Str::from("netId"), Str::from("2")),
                 (Str::from("caps"), Str::from("Xf")),
             ]),
@@ -922,7 +910,7 @@ mod tests {
                     ),
                 ),
             ]),
-            options: HashMap::from_iter([
+            options: Mapping::from_iter([
                 (Str::from("netId"), Str::from("2")),
                 (Str::from("caps"), Str::from("LR")),
             ]),
@@ -963,7 +951,7 @@ mod tests {
                     ),
                 ),
             ]),
-            options: HashMap::from_iter([
+            options: Mapping::from_iter([
                 (Str::from("netId"), Str::from("2")),
                 (Str::from("caps"), Str::from("LR")),
             ]),
@@ -994,7 +982,7 @@ mod tests {
                     RouterAddress::new_unpublished_ssu2([1u8; 32], [2u8; 32], 8888),
                 ),
             ]),
-            options: HashMap::from_iter([
+            options: Mapping::from_iter([
                 (Str::from("netId"), Str::from("2")),
                 (Str::from("caps"), Str::from("LR")),
             ]),

--- a/emissary-core/src/primitives/string.rs
+++ b/emissary-core/src/primitives/string.rs
@@ -137,6 +137,7 @@ impl Str {
     pub fn serialize(&self) -> Vec<u8> {
         let mut out = BytesMut::with_capacity(self.len() + 1);
 
+        debug_assert!(self.len() <= u8::MAX as usize);
         out.put_u8(self.len() as u8);
         out.put_slice(self.as_bytes());
 

--- a/emissary-core/src/primitives/string.rs
+++ b/emissary-core/src/primitives/string.rs
@@ -134,7 +134,7 @@ impl Eq for Str {}
 
 impl Str {
     /// Serialize [`Str`] into a byte vector.
-    pub fn serialize(self) -> Vec<u8> {
+    pub fn serialize(&self) -> Vec<u8> {
         let mut out = BytesMut::with_capacity(self.len() + 1);
 
         out.put_u8(self.len() as u8);

--- a/emissary-core/src/transport/ntcp2/session/mod.rs
+++ b/emissary-core/src/transport/ntcp2/session/mod.rs
@@ -445,7 +445,8 @@ mod tests {
         events::EventManager,
         i2np::{MessageBuilder, MessageType, I2NP_MESSAGE_EXPIRATION},
         primitives::{
-            Capabilities, Date, RouterAddress, RouterIdentity, RouterInfo, Str, TransportKind,
+            Capabilities, Date, Mapping, RouterAddress, RouterIdentity, RouterInfo, Str,
+            TransportKind,
         },
         profile::ProfileStorage,
         runtime::{
@@ -524,7 +525,7 @@ mod tests {
                         8888,
                     )),
                 )]),
-                options: HashMap::from_iter([
+                options: Mapping::from_iter([
                     (Str::from("netId"), Str::from(self.net_id.to_string())),
                     (Str::from("caps"), Str::from("L")),
                 ]),

--- a/emissary-core/src/tunnel/pool/mod.rs
+++ b/emissary-core/src/tunnel/pool/mod.rs
@@ -24,7 +24,7 @@ use crate::{
         garlic::{DeliveryInstructions, GarlicMessageBuilder},
         MessageBuilder, MessageType, I2NP_MESSAGE_EXPIRATION,
     },
-    primitives::{Lease, MessageId, RouterId, Str, TunnelId},
+    primitives::{Lease, Mapping, MessageId, RouterId, Str, TunnelId},
     router::context::RouterContext,
     runtime::{Counter, Gauge, Histogram, Instant, JoinSet, MetricsHandle, Runtime},
     tunnel::{
@@ -133,8 +133,8 @@ impl Default for TunnelPoolConfig {
     }
 }
 
-impl From<&HashMap<Str, Str>> for TunnelPoolConfig {
-    fn from(options: &HashMap<Str, Str>) -> Self {
+impl From<&Mapping> for TunnelPoolConfig {
+    fn from(options: &Mapping) -> Self {
         let num_inbound = options
             .get(&Str::from("inbound.quantity"))
             .map_or(3usize, |value| value.parse::<usize>().unwrap_or(3usize));


### PR DESCRIPTION
This PR aims to close https://github.com/altonen/emissary/issues/62

Refactors `Mapping` to be a `HashMap<Str, Str>` and converts usages of `HashMap<Str, Str>` to `Mapping`.