### PR TITLE
 Respond to NextKey if no traffic is sent

### DIFF
--- a/emissary-core/src/destination/session/mod.rs
+++ b/emissary-core/src/destination/session/mod.rs
@@ -1042,11 +1042,7 @@ mod tests {
         primitives::{Lease, LeaseSet2, LeaseSet2Header, RouterId, TunnelId},
         runtime::mock::MockRuntime,
     };
-    use core::{
-        future::{poll_fn, IntoFuture},
-        time::Duration,
-    };
-    use futures::poll;
+    use core::{future::IntoFuture, time::Duration};
     use rand::thread_rng;
 
     /// Decrypt `message` using `session` and verify the inbound `Data` message

--- a/emissary-core/src/destination/session/mod.rs
+++ b/emissary-core/src/destination/session/mod.rs
@@ -1042,7 +1042,7 @@ mod tests {
         primitives::{Lease, LeaseSet2, LeaseSet2Header, RouterId, TunnelId},
         runtime::mock::MockRuntime,
     };
-    use core::{future::IntoFuture, time::Duration};
+    use core::time::Duration;
     use rand::thread_rng;
 
     /// Decrypt `message` using `session` and verify the inbound `Data` message

--- a/emissary-core/src/destination/session/session.rs
+++ b/emissary-core/src/destination/session/session.rs
@@ -829,6 +829,11 @@ impl<R: Runtime> Session<R> {
         }
     }
 
+    /// Returns true if there is a pending next key
+    pub fn has_pending_next_key(&self) -> bool {
+        self.pending_next_key.is_some()
+    }
+
     /// Decrypt `message` using `garlic_tag` which identifies a `TagSetEntry`.
     ///
     /// Retuns the tag set ID and tag index of the decrypted message, along with the message itself.


### PR DESCRIPTION
Similar to https://github.com/altonen/emissary/pull/78, this PR adds a timer to send an empty message with a NextKey response if there is no upper level traffic.