### PR TITLE
ssu2: Improve pending inbound/outbound sessions

### DIFF
--- a/emissary-core/src/error.rs
+++ b/emissary-core/src/error.rs
@@ -48,6 +48,9 @@ pub enum Ssu2Error {
 
     /// Unexpected message.
     UnexpectedMessage,
+
+    /// Token mismatch.
+    TokenMismatch,
 }
 
 impl fmt::Display for Ssu2Error {
@@ -60,6 +63,7 @@ impl fmt::Display for Ssu2Error {
             Self::NotEnoughBytes => write!(f, "packet is too short"),
             Self::SessionTerminated(reason) => write!(f, "session forcibly terminated: {reason:?}"),
             Self::UnexpectedMessage => write!(f, "unexpected message"),
+            Self::TokenMismatch => write!(f, "token mismatch"),
         }
     }
 }

--- a/emissary-core/src/error.rs
+++ b/emissary-core/src/error.rs
@@ -51,6 +51,9 @@ pub enum Ssu2Error {
 
     /// Token mismatch.
     TokenMismatch,
+
+    /// Network mismatch.
+    NetworkMismatch,
 }
 
 impl fmt::Display for Ssu2Error {
@@ -64,6 +67,7 @@ impl fmt::Display for Ssu2Error {
             Self::SessionTerminated(reason) => write!(f, "session forcibly terminated: {reason:?}"),
             Self::UnexpectedMessage => write!(f, "unexpected message"),
             Self::TokenMismatch => write!(f, "token mismatch"),
+            Self::NetworkMismatch => write!(f, "network mismatch"),
         }
     }
 }

--- a/emissary-core/src/primitives/router_address.rs
+++ b/emissary-core/src/primitives/router_address.rs
@@ -120,7 +120,7 @@ impl RouterAddress {
         options.insert(Str::from("i"), Str::from(base64_encode(iv)));
 
         Self {
-            cost: 10,
+            cost: 3,
             expires: Date::new(0),
             transport: TransportKind::Ntcp2,
             options,
@@ -183,7 +183,7 @@ impl RouterAddress {
         options.insert(Str::from("port"), Str::from(port.to_string()));
 
         Self {
-            cost: 10,
+            cost: 8,
             expires: Date::new(0),
             transport: TransportKind::Ssu2,
             options,
@@ -281,7 +281,7 @@ mod tests {
         let static_key = StaticPrivateKey::from([1u8; 32]).public();
 
         let address = RouterAddress::parse(&serialized).unwrap();
-        assert_eq!(address.cost, 10);
+        assert_eq!(address.cost, 3);
         assert_eq!(
             address.options.get(&Str::from("i")),
             Some(&Str::from(base64_encode(&[0xaa; 16])))
@@ -336,7 +336,7 @@ mod tests {
         let intro_key = [2u8; 32];
 
         let address = RouterAddress::parse(&serialized).unwrap();
-        assert_eq!(address.cost, 10);
+        assert_eq!(address.cost, 8);
         assert_eq!(
             address.options.get(&Str::from("s")),
             Some(&Str::from(base64_encode(&static_key)))

--- a/emissary-core/src/transport/ssu2/message.rs
+++ b/emissary-core/src/transport/ssu2/message.rs
@@ -1843,7 +1843,7 @@ impl<'a> HeaderReader<'a> {
                 let pkt_num = u32::from_be(header as u32);
 
                 // expected to succeed as the packet has been confirmed to be long enough
-                let token = u64::from_le_bytes(
+                let token = u64::from_be_bytes(
                     TryInto::<[u8; 8]>::try_into(&self.pkt[24..32]).expect("to succeed"),
                 );
 

--- a/emissary-core/src/transport/ssu2/message.rs
+++ b/emissary-core/src/transport/ssu2/message.rs
@@ -1724,6 +1724,8 @@ pub struct HeaderReader<'a> {
 
 impl<'a> HeaderReader<'a> {
     /// Create new [`HeaderReader`].
+    ///
+    /// Minimum size for `pkt` is 24 bytes as the IVs used for header decryption as 12 bytes long.
     pub fn new(k_header_1: [u8; 32], pkt: &'a mut [u8]) -> Result<Self, Ssu2Error> {
         if pkt.len() < PKT_MIN_SIZE {
             return Err(Ssu2Error::NotEnoughBytes);
@@ -1757,7 +1759,10 @@ impl<'a> HeaderReader<'a> {
         u64::from_le_bytes(TryInto::<[u8; 8]>::try_into(&self.pkt[..8]).expect("to succeed"))
     }
 
-    // Reset key.
+    /// Reset key.
+    ///
+    /// Used for during pending outbound connections when the first and second part of the short
+    /// header are encrypted not with our intro key but remote's intro key.
     pub fn reset_key(&mut self, k_header_1: [u8; 32]) -> &mut Self {
         self.apply_mask(self.k_header_1, self.iv1, 0..8);
         self.apply_mask(self.k_header_1, self.iv2, 8..16);
@@ -1767,21 +1772,27 @@ impl<'a> HeaderReader<'a> {
     }
 
     /// Attempt to parse the second part of the header using `k_header_2`.
-    //
-    // TODO: explain in more detail
-    pub fn parse(&mut self, k_header_2: [u8; 32]) -> Option<HeaderKind> {
+    ///
+    /// Apply mask for the second part of the short header and extract message type from the header.
+    /// Based on the type of the message, decrypt additional header fields (if the message type
+    /// indicated a long header) and return all useful context to caller for further processing.
+    pub fn parse(&mut self, k_header_2: [u8; 32]) -> Result<HeaderKind, Ssu2Error> {
         self.apply_mask(k_header_2, self.iv2, 8..16);
 
         let header =
             u64::from_le_bytes(TryInto::<[u8; 8]>::try_into(&self.pkt[8..16]).expect("to succeed"));
 
-        match MessageType::try_from(((header >> 32) & 0xff) as u8).ok()? {
+        match MessageType::try_from(((header >> 32) & 0xff) as u8)
+            .map_err(|_| Ssu2Error::Malformed)?
+        {
             MessageType::SessionRequest => {
                 if ((header >> 40) as u8) != PROTOCOL_VERSION {
-                    return None;
+                    return Err(Ssu2Error::InvalidVersion);
                 }
 
-                // TODO: ensure packet has enough bytes
+                if self.pkt.len() < 64 {
+                    return Err(Ssu2Error::NotEnoughBytes);
+                }
 
                 ChaCha::with_iv(k_header_2, [0u8; 12]).decrypt_ref(&mut self.pkt[16..64]);
 
@@ -1795,7 +1806,7 @@ impl<'a> HeaderReader<'a> {
                 let ephemeral_key =
                     EphemeralPublicKey::from_bytes(&self.pkt[32..64]).expect("to succeed");
 
-                Some(HeaderKind::SessionRequest {
+                Ok(HeaderKind::SessionRequest {
                     ephemeral_key,
                     net_id,
                     pkt_num,
@@ -1804,10 +1815,12 @@ impl<'a> HeaderReader<'a> {
             }
             MessageType::SessionCreated => {
                 if ((header >> 40) as u8) != PROTOCOL_VERSION {
-                    return None;
+                    return Err(Ssu2Error::InvalidVersion);
                 }
 
-                // TODO: ensure packet has enough bytes
+                if self.pkt.len() < 64 {
+                    return Err(Ssu2Error::NotEnoughBytes);
+                }
 
                 ChaCha::with_iv(k_header_2, [0u8; 12]).decrypt_ref(&mut self.pkt[16..64]);
 
@@ -1818,24 +1831,26 @@ impl<'a> HeaderReader<'a> {
                 let ephemeral_key =
                     EphemeralPublicKey::from_bytes(&self.pkt[32..64]).expect("to succeed");
 
-                Some(HeaderKind::SessionCreated {
+                Ok(HeaderKind::SessionCreated {
                     ephemeral_key,
                     net_id,
                     pkt_num,
                 })
             }
-            MessageType::SessionConfirmed => Some(HeaderKind::SessionConfirmed {
+            MessageType::SessionConfirmed => Ok(HeaderKind::SessionConfirmed {
                 pkt_num: u32::from_be(header as u32),
             }),
-            MessageType::Data => Some(HeaderKind::Data {
+            MessageType::Data => Ok(HeaderKind::Data {
                 pkt_num: u32::from_be(header as u32),
             }),
             MessageType::Retry => {
                 if ((header >> 40) as u8) != PROTOCOL_VERSION {
-                    return None;
+                    return Err(Ssu2Error::InvalidVersion);
                 }
 
-                // TODO: verify packet length
+                if self.pkt.len() < 32 {
+                    return Err(Ssu2Error::NotEnoughBytes);
+                }
 
                 ChaCha::with_iv(k_header_2, [0u8; 12]).decrypt_ref(&mut self.pkt[16..32]);
 
@@ -1847,7 +1862,7 @@ impl<'a> HeaderReader<'a> {
                     TryInto::<[u8; 8]>::try_into(&self.pkt[24..32]).expect("to succeed"),
                 );
 
-                Some(HeaderKind::Retry {
+                Ok(HeaderKind::Retry {
                     net_id,
                     pkt_num,
                     token,
@@ -1855,7 +1870,11 @@ impl<'a> HeaderReader<'a> {
             }
             MessageType::TokenRequest => {
                 if ((header >> 40) as u8) != PROTOCOL_VERSION {
-                    return None;
+                    return Err(Ssu2Error::InvalidVersion);
+                }
+
+                if self.pkt.len() < 32 {
+                    return Err(Ssu2Error::NotEnoughBytes);
                 }
 
                 ChaCha::with_iv(k_header_2, [0u8; 12]).decrypt_ref(&mut self.pkt[16..32]);
@@ -1866,7 +1885,7 @@ impl<'a> HeaderReader<'a> {
                     TryInto::<[u8; 8]>::try_into(&self.pkt[16..24]).expect("to succeed"),
                 );
 
-                Some(HeaderKind::TokenRequest {
+                Ok(HeaderKind::TokenRequest {
                     net_id,
                     pkt_num,
                     src_id,
@@ -1878,7 +1897,7 @@ impl<'a> HeaderReader<'a> {
                     ?message_type,
                     "unsupported message type",
                 );
-                None
+                Err(Ssu2Error::UnexpectedMessage)
             }
         }
     }

--- a/emissary-core/src/transport/ssu2/session/pending/mod.rs
+++ b/emissary-core/src/transport/ssu2/session/pending/mod.rs
@@ -119,11 +119,14 @@ impl<R: Runtime> PacketRetransmitter<R> {
     ///
     /// Used by a pending inbound session when a `Retry` message has been sent but no message has
     /// been received as a response.
-    pub fn inactive() -> Self {
+    ///
+    /// `timeout` specifies how long a new `TokenRequest`/`SessionRequest` is awaited before the
+    /// inbound session is destroyed.
+    pub fn inactive(timeout: Duration) -> Self {
         Self {
             pkt: Vec::new(),
             timeouts: VecDeque::new(),
-            timer: R::timer(Duration::MAX),
+            timer: R::timer(timeout),
         }
     }
 

--- a/emissary-core/src/transport/ssu2/session/pending/outbound.rs
+++ b/emissary-core/src/transport/ssu2/session/pending/outbound.rs
@@ -273,6 +273,8 @@ impl<R: Runtime> OutboundSsu2Session<R> {
             router_id = %self.router_id,
             dst_id = ?self.dst_id,
             src_id = ?self.src_id,
+            ?pkt_num,
+            ?token,
             "handle `Retry`",
         );
 

--- a/emissary-core/src/transport/ssu2/session/pending/outbound.rs
+++ b/emissary-core/src/transport/ssu2/session/pending/outbound.rs
@@ -361,6 +361,23 @@ impl<R: Runtime> OutboundSsu2Session<R> {
 
                 ephemeral_key
             }
+            HeaderKind::Retry { token, .. } => {
+                tracing::debug!(
+                    target: LOG_TARGET,
+                    router_id = %self.router_id,
+                    dst_id = ?self.dst_id,
+                    src_id = ?self.src_id,
+                    ?token,
+                    "received unexpected `Retry`, ignoring",
+                );
+
+                self.state =  PendingSessionState::AwaitingSessionCreated {
+                    ephemeral_key,
+                    local_static_key,
+                    router_info,
+                };
+                return Ok(None);
+            },
             kind => {
                 tracing::debug!(
                     target: LOG_TARGET,

--- a/emissary-core/src/transport/ssu2/session/pending/outbound.rs
+++ b/emissary-core/src/transport/ssu2/session/pending/outbound.rs
@@ -45,6 +45,7 @@ use zeroize::Zeroize;
 
 use alloc::vec::Vec;
 use core::{
+    fmt,
     future::Future,
     mem,
     net::SocketAddr,
@@ -125,6 +126,22 @@ enum PendingSessionState {
 
     /// State has been poisoned.
     Poisoned,
+}
+
+impl fmt::Debug for PendingSessionState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PendingSessionState::AwaitingRetry { .. } =>
+                f.debug_struct("PendingSessionState::AwaitingRetry").finish_non_exhaustive(),
+            PendingSessionState::AwaitingSessionCreated { .. } => f
+                .debug_struct("PendingSessionState::AwaitingSessionCreated")
+                .finish_non_exhaustive(),
+            PendingSessionState::AwaitingFirstAck =>
+                f.debug_struct("PendingSessionState::AwaitingFirstAck").finish(),
+            PendingSessionState::Poisoned =>
+                f.debug_struct("PendingSessionState::Poisoned").finish(),
+        }
+    }
 }
 
 /// Pending outbound SSU2 session.
@@ -256,13 +273,13 @@ impl<R: Runtime> OutboundSsu2Session<R> {
                 (pkt_num, token)
             }
             kind => {
-                tracing::debug!(
+                tracing::warn!(
                     target: LOG_TARGET,
                     router_id = %self.router_id,
                     dst_id = ?self.dst_id,
                     src_id = ?self.src_id,
                     ?kind,
-                    "invalid message, expected `Retry`",
+                    "unexpected message, expected `Retry`",
                 );
                 return Err(Ssu2Error::UnexpectedMessage);
             }
@@ -363,14 +380,14 @@ impl<R: Runtime> OutboundSsu2Session<R> {
 
                 ephemeral_key
             }
-            HeaderKind::Retry { token, .. } => {
+            kind => {
                 tracing::debug!(
                     target: LOG_TARGET,
                     router_id = %self.router_id,
                     dst_id = ?self.dst_id,
                     src_id = ?self.src_id,
-                    ?token,
-                    "received unexpected `Retry`, ignoring",
+                    ?kind,
+                    "unexpected message, expected `SessionCreated`",
                 );
 
                 self.state =  PendingSessionState::AwaitingSessionCreated {
@@ -379,17 +396,6 @@ impl<R: Runtime> OutboundSsu2Session<R> {
                     router_info,
                 };
                 return Ok(None);
-            },
-            kind => {
-                tracing::debug!(
-                    target: LOG_TARGET,
-                    router_id = %self.router_id,
-                    dst_id = ?self.dst_id,
-                    src_id = ?self.src_id,
-                    ?kind,
-                    "invalid message, expected `SessionCreated`",
-                );
-                return Err(Ssu2Error::UnexpectedMessage);
             }
         };
 
@@ -474,18 +480,7 @@ impl<R: Runtime> OutboundSsu2Session<R> {
     /// <https://geti2p.net/spec/ssu2#kdf-for-session-confirmed-part-2>
     /// <https://geti2p.net/spec/ssu2#sessionconfirmed-type-2>
     /// <https://geti2p.net/spec/ssu2#kdf-for-data-phase>
-    fn on_data(&mut self, _pkt: Vec<u8>) -> Result<Option<PendingSsu2SessionStatus>, Ssu2Error> {
-        // TODO: implement data packet parse
-        // TODO: verify ack was received
-
-        tracing::trace!(
-            target: LOG_TARGET,
-            router_id = %self.router_id,
-            dst_id = ?self.dst_id,
-            src_id = ?self.src_id,
-            "handle `Data` (first ack)",
-        );
-
+    fn on_data(&mut self, mut pkt: Vec<u8>) -> Result<Option<PendingSsu2SessionStatus>, Ssu2Error> {
         let temp_key = Hmac::new(self.noise_ctx.chaining_key()).update([]).finalize();
         let k_ab = Hmac::new(&temp_key).update([0x01]).finalize();
         let k_ba = Hmac::new(&temp_key).update(&k_ab).update([0x02]).finalize();
@@ -510,6 +505,31 @@ impl<R: Runtime> OutboundSsu2Session<R> {
             .update(b"HKDFSSU2DataKeys")
             .update([0x02])
             .finalize_new();
+
+        match HeaderReader::new(self.intro_key, &mut pkt)?.parse(k_header_2_ba) {
+            Some(HeaderKind::Data { .. }) => {}
+            kind => {
+                tracing::debug!(
+                    target: LOG_TARGET,
+                    router_id = %self.router_id,
+                    dst_id = ?self.dst_id,
+                    src_id = ?self.src_id,
+                    ?kind,
+                    "unexpected message, expected `Data`",
+                );
+
+                self.state = PendingSessionState::AwaitingFirstAck;
+                return Ok(None);
+            }
+        };
+
+        tracing::trace!(
+            target: LOG_TARGET,
+            router_id = %self.router_id,
+            dst_id = ?self.dst_id,
+            src_id = ?self.src_id,
+            "handle `Data` (first ack)",
+        );
 
         Ok(Some(PendingSsu2SessionStatus::NewOutboundSession {
             context: Ssu2SessionContext {
@@ -602,6 +622,14 @@ impl<R: Runtime> Future for OutboundSsu2Session<R> {
 
         match futures::ready!(self.pkt_retransmitter.poll_unpin(cx)) {
             PacketRetransmitterEvent::Retransmit { pkt } => {
+                tracing::trace!(
+                    target: LOG_TARGET,
+                    dst_id = ?self.dst_id,
+                    src_id = ?self.src_id,
+                    state = ?self.state,
+                    "retransmitting packet",
+                );
+
                 if let Err(error) = self.pkt_tx.try_send(Packet {
                     pkt: pkt.clone(),
                     address: self.address,
@@ -622,6 +650,393 @@ impl<R: Runtime> Future for OutboundSsu2Session<R> {
                 connection_id: self.src_id,
                 router_id: Some(self.router_id.clone()),
             }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        crypto::sha256::Sha256,
+        primitives::RouterInfoBuilder,
+        runtime::mock::MockRuntime,
+        transport::ssu2::session::pending::inbound::{InboundSsu2Context, InboundSsu2Session},
+    };
+    use rand_core::RngCore;
+    use std::{
+        net::{IpAddr, Ipv4Addr},
+        time::Duration,
+    };
+    use thingbuf::mpsc::channel;
+
+    struct InboundContext {
+        inbound_session: InboundSsu2Session<MockRuntime>,
+        inbound_session_tx: Sender<Packet>,
+        inbound_socket_rx: Receiver<Packet>,
+    }
+
+    struct OutboundContext {
+        outbound_session: OutboundSsu2Session<MockRuntime>,
+        outbound_session_tx: Sender<Packet>,
+        outbound_socket_rx: Receiver<Packet>,
+    }
+
+    fn create_session() -> (InboundContext, OutboundContext) {
+        let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
+        let src_id = MockRuntime::rng().next_u64();
+        let dst_id = MockRuntime::rng().next_u64();
+
+        let outbound_static_key = StaticPrivateKey::random(MockRuntime::rng());
+        let inbound_static_key = StaticPrivateKey::random(MockRuntime::rng());
+        let inbound_intro_key = {
+            let mut key = [0u8; 32];
+            MockRuntime::rng().fill_bytes(&mut key);
+
+            key
+        };
+
+        let state = Sha256::new()
+            .update("Noise_XKchaobfse+hs1+hs2+hs3_25519_ChaChaPoly_SHA256".as_bytes())
+            .finalize();
+        let chaining_key = state.clone();
+        let outbound_state = Sha256::new().update(&state).finalize();
+        let inbound_state = Sha256::new()
+            .update(&outbound_state)
+            .update(inbound_static_key.public().to_vec())
+            .finalize();
+
+        let (inbound_socket_tx, inbound_socket_rx) = channel(128);
+        let (inbound_session_tx, inbound_session_rx) = channel(128);
+        let (outbound_socket_tx, outbound_socket_rx) = channel(128);
+        let (outbound_session_tx, outbound_session_rx) = channel(128);
+
+        let (router_info, _, signing_key) = RouterInfoBuilder::default()
+            .with_ssu2(crate::Ssu2Config {
+                port: 8889,
+                host: Some(Ipv4Addr::new(127, 0, 0, 1)),
+                publish: true,
+                static_key: TryInto::<[u8; 32]>::try_into(outbound_static_key.as_ref().to_vec())
+                    .unwrap(),
+                intro_key: {
+                    let mut key = [0u8; 32];
+                    MockRuntime::rng().fill_bytes(&mut key);
+
+                    key
+                },
+            })
+            .build();
+
+        let outbound = OutboundSsu2Session::new(OutboundSsu2Context {
+            address,
+            chaining_key: Bytes::from(chaining_key.clone()),
+            dst_id,
+            intro_key: inbound_intro_key,
+            local_static_key: outbound_static_key,
+            pkt_tx: outbound_socket_tx,
+            router_id: router_info.identity.id(),
+            router_info: Bytes::from(router_info.serialize(&signing_key)),
+            rx: outbound_session_rx,
+            src_id,
+            state: inbound_state.clone(),
+            static_key: inbound_static_key.public(),
+        });
+
+        let (pkt, pkt_num, dst_id, src_id) = {
+            let Packet { mut pkt, .. } = outbound_socket_rx.try_recv().unwrap();
+            let mut reader = HeaderReader::new(inbound_intro_key, &mut pkt).unwrap();
+            let dst_id = reader.dst_id();
+
+            match reader.parse(inbound_intro_key) {
+                Some(HeaderKind::TokenRequest {
+                    pkt_num, src_id, ..
+                }) => (pkt, pkt_num, dst_id, src_id),
+                _ => panic!("invalid message"),
+            }
+        };
+
+        let inbound = InboundSsu2Session::<MockRuntime>::new(InboundSsu2Context {
+            address,
+            chaining_key: Bytes::from(chaining_key),
+            dst_id,
+            intro_key: inbound_intro_key,
+            pkt,
+            pkt_num,
+            pkt_tx: inbound_socket_tx,
+            rx: inbound_session_rx,
+            src_id,
+            state: Bytes::from(inbound_state),
+            static_key: inbound_static_key.clone(),
+        })
+        .unwrap();
+
+        (
+            InboundContext {
+                inbound_socket_rx,
+                inbound_session_tx,
+                inbound_session: inbound,
+            },
+            OutboundContext {
+                outbound_socket_rx,
+                outbound_session_tx,
+                outbound_session: outbound,
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn token_request_timeout() {
+        let (
+            InboundContext { .. },
+            OutboundContext {
+                outbound_session,
+                outbound_session_tx: _ob_sess_tx,
+                outbound_socket_rx,
+            },
+        ) = create_session();
+        let outbound_session = tokio::spawn(outbound_session);
+
+        for _ in 0..2 {
+            match tokio::time::timeout(Duration::from_secs(10), outbound_socket_rx.recv()).await {
+                Err(_) => panic!("timeout"),
+                Ok(None) => panic!("error"),
+                Ok(Some(_)) => {}
+            }
+        }
+
+        match tokio::time::timeout(Duration::from_secs(10), outbound_session).await {
+            Err(_) => panic!("timeout"),
+            Ok(Err(_)) => panic!("error"),
+            Ok(Ok(PendingSsu2SessionStatus::Timeout { .. })) => {}
+            _ => panic!("invalid result"),
+        }
+    }
+
+    #[tokio::test]
+    async fn session_request_timeout() {
+        let (
+            InboundContext {
+                inbound_session: _ib_session,
+                inbound_socket_rx,
+                inbound_session_tx: _ib_sess_tx,
+            },
+            OutboundContext {
+                outbound_session,
+                outbound_session_tx: ob_sess_tx,
+                outbound_socket_rx,
+            },
+        ) = create_session();
+
+        let intro_key = outbound_session.intro_key;
+        let outbound_session = tokio::spawn(outbound_session);
+
+        // send retry message to outbound session
+        {
+            let Packet { mut pkt, address } = inbound_socket_rx.try_recv().unwrap();
+            let mut reader = HeaderReader::new(intro_key, &mut pkt).unwrap();
+            let _connection_id = reader.dst_id();
+
+            ob_sess_tx.send(Packet { pkt, address }).await.unwrap();
+        }
+
+        for _ in 0..3 {
+            match tokio::time::timeout(Duration::from_secs(10), outbound_socket_rx.recv()).await {
+                Err(_) => panic!("timeout"),
+                Ok(None) => panic!("error"),
+                Ok(Some(_)) => {}
+            }
+        }
+
+        match tokio::time::timeout(Duration::from_secs(20), outbound_session).await {
+            Err(_) => panic!("timeout"),
+            Ok(Err(_)) => panic!("error"),
+            Ok(Ok(PendingSsu2SessionStatus::Timeout { .. })) => {}
+            _ => panic!("invalid result"),
+        }
+    }
+
+    #[tokio::test]
+    async fn session_confirmed_timeout() {
+        let (
+            InboundContext {
+                inbound_session,
+                inbound_socket_rx,
+                inbound_session_tx: ib_sess_tx,
+            },
+            OutboundContext {
+                outbound_session,
+                outbound_session_tx: ob_sess_tx,
+                outbound_socket_rx,
+            },
+        ) = create_session();
+
+        let intro_key = outbound_session.intro_key;
+        let outbound_session = tokio::spawn(outbound_session);
+        let _inbound_session = tokio::spawn(inbound_session);
+
+        // send retry message to outbound session
+        {
+            let Packet { mut pkt, address } = inbound_socket_rx.try_recv().unwrap();
+            let mut reader = HeaderReader::new(intro_key, &mut pkt).unwrap();
+            let _connection_id = reader.dst_id();
+
+            ob_sess_tx.send(Packet { pkt, address }).await.unwrap();
+        }
+
+        // read session request from outbound session and send it to inbound session
+        {
+            let Packet { mut pkt, address } = outbound_socket_rx.recv().await.unwrap();
+            let mut reader = HeaderReader::new(intro_key, &mut pkt).unwrap();
+            let _connection_id = reader.dst_id();
+            ib_sess_tx.send(Packet { pkt, address }).await.unwrap();
+        }
+
+        // send session created to outbound session
+        {
+            let Packet { mut pkt, address } = inbound_socket_rx.recv().await.unwrap();
+            let mut reader = HeaderReader::new(intro_key, &mut pkt).unwrap();
+            let _connection_id = reader.dst_id();
+
+            ob_sess_tx.send(Packet { pkt, address }).await.unwrap();
+        }
+
+        for _ in 0..3 {
+            match tokio::time::timeout(Duration::from_secs(10), outbound_socket_rx.recv()).await {
+                Err(_) => panic!("timeout"),
+                Ok(None) => panic!("error"),
+                Ok(Some(_)) => {}
+            }
+        }
+
+        match tokio::time::timeout(Duration::from_secs(20), outbound_session).await {
+            Err(_) => panic!("timeout"),
+            Ok(Err(_)) => panic!("error"),
+            Ok(Ok(PendingSsu2SessionStatus::Timeout { .. })) => {}
+            _ => panic!("invalid result"),
+        }
+    }
+
+    #[tokio::test]
+    async fn duplicate_session_created_received() {
+        let (
+            InboundContext {
+                inbound_session,
+                inbound_socket_rx,
+                inbound_session_tx: ib_sess_tx,
+            },
+            OutboundContext {
+                mut outbound_session,
+                outbound_session_tx: ob_sess_tx,
+                outbound_socket_rx,
+            },
+        ) = create_session();
+
+        let intro_key = outbound_session.intro_key;
+        let inbound_session = tokio::spawn(inbound_session);
+
+        // send retry message to outbound session
+        {
+            let Packet { mut pkt, address } = inbound_socket_rx.try_recv().unwrap();
+            let mut reader = HeaderReader::new(intro_key, &mut pkt).unwrap();
+            let _connection_id = reader.dst_id();
+
+            ob_sess_tx.send(Packet { pkt, address }).await.unwrap();
+        }
+
+        // read session request from outbound session and send it to inbound session
+        {
+            let Packet { mut pkt, address } = tokio::select! {
+                _ = &mut outbound_session => unreachable!(),
+                pkt = outbound_socket_rx.recv() => {
+                    pkt.unwrap()
+                }
+            };
+
+            let mut reader = HeaderReader::new(intro_key, &mut pkt).unwrap();
+            let _connection_id = reader.dst_id();
+            ib_sess_tx.send(Packet { pkt, address }).await.unwrap();
+        }
+
+        // read `SessionCreated` from inbound session twice and relay it to outbound session
+        //
+        // verify that outbound session handles the duplicate packet gracefully and keeps waiting
+        // for the first ack packet
+        for _ in 0..2 {
+            {
+                let Packet { mut pkt, address } = inbound_socket_rx.recv().await.unwrap();
+                let mut reader = HeaderReader::new(intro_key, &mut pkt).unwrap();
+                let _connection_id = reader.dst_id();
+                ob_sess_tx.send(Packet { pkt, address }).await.unwrap();
+            }
+
+            // verify that outbound session responds
+            let _pkt = tokio::select! {
+                _ = &mut outbound_session => unreachable!(),
+                pkt = outbound_socket_rx.recv() => {
+                    pkt.unwrap()
+                }
+                _ = tokio::time::sleep(Duration::from_secs(5)) => panic!("timeout"),
+            };
+
+            match outbound_session.state {
+                PendingSessionState::AwaitingFirstAck => {}
+                _ => panic!("invalid state"),
+            }
+        }
+
+        // read session created from inbound session and relay it to outbound session
+        {
+            let Packet { mut pkt, address } = inbound_socket_rx.recv().await.unwrap();
+            let mut reader = HeaderReader::new(intro_key, &mut pkt).unwrap();
+            let _connection_id = reader.dst_id();
+            ob_sess_tx.send(Packet { pkt, address }).await.unwrap();
+        }
+
+        // read session confirmed from outbound session and relay it to inbound session
+        {
+            let Packet { mut pkt, address } = tokio::select! {
+                _ = &mut outbound_session => unreachable!(),
+                pkt = outbound_socket_rx.recv() => {
+                    pkt.unwrap()
+                }
+                _ = tokio::time::sleep(Duration::from_secs(5)) => panic!("timeout"),
+            };
+
+            let mut reader = HeaderReader::new(intro_key, &mut pkt).unwrap();
+            let _connection_id = reader.dst_id();
+            ib_sess_tx.send(Packet { pkt, address }).await.unwrap();
+        }
+
+        // verify that inbound session considers the connection opened
+        //
+        // relay the first ack packet to outbound session
+        match tokio::time::timeout(Duration::from_secs(5), inbound_session)
+            .await
+            .expect("no timeout")
+            .expect("to succeed")
+        {
+            PendingSsu2SessionStatus::NewInboundSession {
+                mut pkt, target, ..
+            } => {
+                let mut reader = HeaderReader::new(intro_key, &mut pkt).unwrap();
+                let _connection_id = reader.dst_id();
+                ob_sess_tx
+                    .send(Packet {
+                        pkt: pkt.to_vec(),
+                        address: target,
+                    })
+                    .await
+                    .unwrap();
+            }
+            _ => panic!("invalid session state"),
+        }
+
+        match tokio::time::timeout(Duration::from_secs(5), outbound_session)
+            .await
+            .expect("no timeout")
+        {
+            PendingSsu2SessionStatus::NewOutboundSession { .. } => {}
+            _ => panic!("invalid session state"),
         }
     }
 }

--- a/emissary-core/src/transport/ssu2/session/pending/outbound.rs
+++ b/emissary-core/src/transport/ssu2/session/pending/outbound.rs
@@ -582,14 +582,21 @@ impl<R: Runtime> Future for OutboundSsu2Session<R> {
             match self.on_packet(pkt) {
                 Ok(None) => {}
                 Ok(Some(status)) => return Poll::Ready(status),
-                Err(error) => tracing::debug!(
-                    target: LOG_TARGET,
-                    router_id = %self.router_id,
-                    dst_id = ?self.dst_id,
-                    src_id = ?self.src_id,
-                    ?error,
-                    "failed to handle packet",
-                ),
+                Err(error) => {
+                    tracing::debug!(
+                        target: LOG_TARGET,
+                        router_id = %self.router_id,
+                        dst_id = ?self.dst_id,
+                        src_id = ?self.src_id,
+                        ?error,
+                        "failed to handle packet",
+                    );
+
+                    return Poll::Ready(PendingSsu2SessionStatus::SessionTermianted {
+                        connection_id: self.src_id,
+                        router_id: None,
+                    });
+                }
             }
         }
 

--- a/emissary-core/src/transport/ssu2/session/terminating.rs
+++ b/emissary-core/src/transport/ssu2/session/terminating.rs
@@ -164,8 +164,7 @@ impl<R: Runtime> TerminatingSsu2Session<R> {
     /// with a data message containing a termination block.
     fn on_packet(&mut self, mut pkt: Vec<u8>) -> Result<(), Ssu2Error> {
         let pkt_num = match HeaderReader::new(self.intro_key, &mut pkt)?
-            .parse(self.recv_key_ctx.k_header_2)
-            .ok_or(Ssu2Error::InvalidVersion)? // TODO: could be other error
+            .parse(self.recv_key_ctx.k_header_2)?
         {
             HeaderKind::Data { pkt_num } => pkt_num,
             kind => {

--- a/emissary-core/src/transport/ssu2/socket.rs
+++ b/emissary-core/src/transport/ssu2/socket.rs
@@ -233,14 +233,15 @@ impl<R: Runtime> Ssu2Socket<R> {
                 let (tx, rx) = channel(CHANNEL_SIZE);
                 let session = InboundSsu2Session::<R>::new(InboundSsu2Context {
                     address,
-                    src_id,
-                    pkt_num,
                     chaining_key: self.chaining_key.clone(),
                     dst_id: connection_id,
                     intro_key: self.intro_key,
+                    net_id: self.router_ctx.net_id(),
+                    pkt_num,
                     pkt: self.buffer[..nread].to_vec(),
                     pkt_tx: self.pkt_tx.clone(),
                     rx,
+                    src_id,
                     state: self.inbound_state.clone(),
                     static_key: self.static_key.clone(),
                 })?;
@@ -327,6 +328,7 @@ impl<R: Runtime> Ssu2Socket<R> {
             dst_id,
             intro_key,
             local_static_key: self.static_key.clone(),
+            net_id: self.router_ctx.net_id(),
             pkt_tx: self.pkt_tx.clone(),
             router_id,
             router_info,

--- a/emissary-core/src/transport/ssu2/socket.rs
+++ b/emissary-core/src/transport/ssu2/socket.rs
@@ -224,7 +224,7 @@ impl<R: Runtime> Ssu2Socket<R> {
         }
 
         match reader.parse(self.intro_key) {
-            Some(HeaderKind::TokenRequest {
+            Ok(HeaderKind::TokenRequest {
                 net_id: _,
                 pkt_num,
                 src_id,
@@ -251,7 +251,7 @@ impl<R: Runtime> Ssu2Socket<R> {
 
                 Ok(())
             }
-            Some(kind) => {
+            Ok(kind) => {
                 tracing::warn!(
                     target: LOG_TARGET,
                     ?kind,
@@ -259,7 +259,7 @@ impl<R: Runtime> Ssu2Socket<R> {
                 );
                 Ok(())
             }
-            None => match self.pending_outbound.get(&address) {
+            Err(_) => match self.pending_outbound.get(&address) {
                 Some(intro_key) =>
                     match self.sessions.get_mut(&reader.reset_key(*intro_key).dst_id()) {
                         Some(tx) => tx


### PR DESCRIPTION
Gracefully handle retransmitted hanshake packets, check net ID and improve `HandshakeReader` to return correct errors. Adjust published transport costs.

Resolves #56
Resolves #85 