### PR TITLE
cli/http: Use `.b32.i2p` hostnames in HTTP requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,9 +1569,11 @@ dependencies = [
  "metrics-exporter-prometheus",
  "natpmp",
  "netdev 0.33.0",
+ "parking_lot 0.12.3",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "reqwest",
+ "schnellru",
  "serde",
  "serde_json",
  "tempfile",
@@ -2242,6 +2244,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash 0.7.8",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
 name = "hashbrown"
@@ -4799,6 +4807,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "schnellru"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "356285bbf17bea63d9e52e96bd18f039672ac92b55b8cb997d6162a2a37d1649"
+dependencies = [
+ "ahash 0.8.11",
+ "cfg-if",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ ed25519-dalek = { version = "2.1.1", default-features = false }
 flate2 = "1.1.1"
 futures = "0.3.31"
 nom = { version = "7.1.3", default-features = false }
+parking_lot = "0.12.3"
 rand = "0.8.5"
 rand_core = { version = "0.6.3", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }

--- a/emissary-cli/Cargo.toml
+++ b/emissary-cli/Cargo.toml
@@ -26,6 +26,7 @@ metrics-exporter-prometheus = "0.16.2"
 natpmp = "0.5.0"
 netdev = { version = "0.33.0", default-features = false }
 reqwest = { version = "0.12.15", default-features = false, features = ["rustls-tls"] }
+schnellru = "0.2.4"
 serde_json = { version = "1.0.140", optional = true }
 serde = { version = "1.0.219", features = ["derive"] }
 thiserror = "2.0.12"
@@ -37,6 +38,7 @@ url = "2.5.4"
 anyhow = { workspace = true }
 ed25519-dalek = { workspace = true, features = ["rand_core", "fast"] }
 flate2 = { workspace = true }
+parking_lot = { workspace = true }
 rand_core = { workspace = true }
 rand = { workspace = true }
 tokio-util = { workspace = true }

--- a/emissary-core/Cargo.toml
+++ b/emissary-core/Cargo.toml
@@ -28,7 +28,6 @@ lazy_static = { version = "1.5.0", default-features = false }
 num-bigint = { version = "0.4.6", default-features = false }
 num-traits = { version = "0.2.19", default-features = false }
 p256 = { version = "0.13.2", default-features = false, features = ["alloc", "ecdsa", "ecdsa-core"] }
-parking_lot = { version = "0.12.3", optional = true }
 sha1 = { version = "0.10.6", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
 siphasher = { version = "1.0.1", default-features = false }
@@ -41,6 +40,7 @@ zeroize = { version = "1.8.1", default-features = false, features = ["alloc"] }
 # workspace dependencies
 ed25519-dalek = { workspace = true, features = ["alloc", "rand_core", "fast"] }
 nom = { workspace = true, features = ["alloc"] }
+parking_lot = { workspace = true, optional = true }
 rand_core = { workspace = true, features = ["alloc"] }
 tracing = { workspace = true }
 x25519-dalek = { workspace = true, features = ["reusable_secrets", "static_secrets", "zeroize", "precomputed-tables"] }

--- a/emissary-core/src/crypto/sha256.rs
+++ b/emissary-core/src/crypto/sha256.rs
@@ -26,12 +26,18 @@ pub struct Sha256 {
     hasher: sha2::Sha256,
 }
 
-impl Sha256 {
-    /// Crete new [`Sha256`].
-    pub fn new() -> Self {
+impl Default for Sha256 {
+    fn default() -> Self {
         Self {
             hasher: sha2::Sha256::new(),
         }
+    }
+}
+
+impl Sha256 {
+    /// Crete new [`Sha256`].
+    pub fn new() -> Self {
+        Default::default()
     }
 
     /// Update hasher state.

--- a/emissary-core/src/i2cp/session.rs
+++ b/emissary-core/src/i2cp/session.rs
@@ -238,7 +238,7 @@ impl<R: Runtime> I2cpSession<R> {
                     (Some(address_book), RequestKind::HostName { host_name }) => {
                         self.host_lookups.push(async move {
                             let destination = address_book
-                                .resolve(host_name.to_string())
+                                .resolve_b64(host_name.to_string())
                                 .await
                                 .and_then(base64_decode);
 

--- a/emissary-core/src/lib.rs
+++ b/emissary-core/src/lib.rs
@@ -27,6 +27,7 @@
 #![allow(clippy::module_inception)]
 #![allow(clippy::option_map_unit_fn)]
 #![allow(clippy::manual_div_ceil)]
+#![allow(clippy::should_implement_trait)]
 
 extern crate alloc;
 
@@ -41,7 +42,6 @@ pub use profile::Profile;
 
 mod bloom;
 mod config;
-mod crypto;
 mod destination;
 mod error;
 mod i2cp;
@@ -54,6 +54,7 @@ mod transport;
 mod tunnel;
 mod util;
 
+pub mod crypto;
 pub mod events;
 pub mod i2np;
 pub mod primitives;

--- a/emissary-core/src/runtime/mod.rs
+++ b/emissary-core/src/runtime/mod.rs
@@ -18,7 +18,7 @@
 
 // TODO: documentation
 
-use futures::Stream;
+use futures::{future::Either, Stream};
 use rand_core::{CryptoRng, RngCore};
 
 use alloc::{boxed::Box, string::String, vec::Vec};
@@ -204,7 +204,17 @@ pub trait Runtime: Clone + Unpin + Send + 'static {
 
 pub trait AddressBook: Unpin + Send + Sync + 'static {
     /// Attempt to resolve `host` into a base64-encoded `Destination`.
-    fn resolve(&self, host: String) -> Pin<Box<dyn Future<Output = Option<String>> + Send>>;
+    fn resolve_b64(&self, host: String) -> Pin<Box<dyn Future<Output = Option<String>> + Send>>;
+
+    /// Attempt to resolve `host` into a base64-encoded `Destination`.
+    ///
+    /// Returns `Either::Left` if `host` was found in the cache.
+    ///
+    /// Returns `Either::Right` if `host` was not found in the cache and a lookup was started.
+    fn resolve_b32(
+        &self,
+        host: String,
+    ) -> Either<String, Pin<Box<dyn Future<Output = Option<String>> + Send>>>;
 }
 
 pub trait Storage: Unpin + Send + Sync + 'static {

--- a/emissary-core/src/sam/session.rs
+++ b/emissary-core/src/sam/session.rs
@@ -1104,7 +1104,7 @@ impl<R: Runtime> SamSession<R> {
                         "lookup name from address book",
                     );
 
-                    let future = address_book.resolve(name.clone());
+                    let future = address_book.resolve_b64(name.clone());
                     self.lookup_futures.push(async move { (name, future.await) });
 
                     None


### PR DESCRIPTION
when a `.i2p` hostname is used to connect to an eepsite, convert the value of the `Host` field of the request to a `.b32.i2p` of that host, if it exists in the address book.

introduce `AddressBook::resolve_b32()` which attempts to resolve a `.i2p` hostname into its destination hash and it is found, the value is cached in `AddressBook` in an LRU cache.

Resolves #108