### PR TITLE
SAM command parser: validating tunnel lengths

### DIFF
--- a/emissary-core/src/sam/parser.rs
+++ b/emissary-core/src/sam/parser.rs
@@ -823,12 +823,12 @@ mod tests {
 
     #[test]
     fn reject_invalid_tunnel_lengths() {
-        let test_cases= [("0", "5"), ("5", "9"), ("8", "5"), ("5", "9"),("abc","5"),("5","abc"),("0","0"),("8","9"),("abc","def")];
+        let test_cases= [("0", "5"), ("5", "0"), ("8", "5"), ("5", "9"),("abc","5"),("5","abc"),("0","0"),("8","9"),("abc","def")];
         for (invalid_in_len,invalid_out_len) in test_cases {
             let invalid_cmd = ParsedCommand::<MockRuntime> {
                 command: "SESSION",
                 subcommand: Some("CREATE"),
-                key_value_pairs: HashMap::from([("STYLE", "STREAM"),("ID", "test"),("DESTINATION", "TRANSIENT"),("inbound.length", invalid_in_len),("outbound.length", invalid_out_len),]),
+                key_value_pairs: HashMap::from([("STYLE", "STREAM"),("ID", "test"),("DESTINATION", "TRANSIENT"),("inbound.length", invalid_in_len),("outbound.length", invalid_out_len)]),
                 _runtime: Default::default(),
                 };
             match SamCommand::try_from(invalid_cmd) {

--- a/emissary-core/src/sam/parser.rs
+++ b/emissary-core/src/sam/parser.rs
@@ -855,7 +855,7 @@ mod tests {
 
             match SamCommand::try_from(invalid_cmd) {
                 Ok(_) => panic!(
-                    "Failed to reject the invalid tunnel lengths {:?}",
+                    "Failed to reject the invalid inbound tunnel length {:?}",
                     (invalid_in_len)
                 ),
                 Err(_) => {}
@@ -881,7 +881,7 @@ mod tests {
 
             match SamCommand::try_from(invalid_cmd) {
                 Ok(_) => panic!(
-                    "Failed to reject the invalid tunnel lengths {:?}",
+                    "Failed to reject the invalid outbound tunnel length {:?}",
                     (invalid_out_len)
                 ),
                 Err(_) => {}


### PR DESCRIPTION
An attemp to close the first part of https://github.com/altonen/emissary/issues/94, related to the SAM parser.

The existence of tunnel lengths is checked first, then whether they can be parsed into u8 and finally whether they satisfy the valid ranges for tunnel lengths.

A simple unit test is attached.