### PR TITLE
ssu2: Handle invalid `SessionConfirmed` messages gracefully

### DIFF
--- a/emissary-core/src/transport/ssu2/session/pending/inbound.rs
+++ b/emissary-core/src/transport/ssu2/session/pending/inbound.rs
@@ -484,17 +484,7 @@ impl<R: Runtime> InboundSsu2Session<R> {
         k_session_created: [u8; 32],
     ) -> Result<Option<PendingSsu2SessionStatus<R>>, Ssu2Error> {
         match HeaderReader::new(self.intro_key, &mut pkt)?.parse(k_header_2) {
-            Ok(HeaderKind::SessionConfirmed { pkt_num }) =>
-                if pkt_num != 0 {
-                    tracing::warn!(
-                        target: LOG_TARGET,
-                        dst_id = ?self.dst_id,
-                        src_id = ?self.src_id,
-                        ?pkt_num,
-                        "`SessionConfirmed` contains non-zero packet number",
-                    );
-                    return Err(Ssu2Error::Malformed);
-                },
+            Ok(HeaderKind::SessionConfirmed { .. }) => {}
             kind => {
                 tracing::debug!(
                     target: LOG_TARGET,


### PR DESCRIPTION
Duplicate `SessionCreated` message may be incorrectly identified as `SessionConfirmed` if the `type` field contains the message type for `SessionConfirmed`

Previously the code, after encoutering such a packet, would terminate the pending inbound session instead of discarding the packet as an invalid `SessionConfirmed` packet, causing a test failure

If a `SessionConfirmed` message with a non-zero packet number is received, mark the packet as invalid and allow `InboundSsu2Session` to retransmit the appropriate reply when the timer expires

Resolves #145 