### PR TITLE
sam: Add support for primary sessions

### DIFF
--- a/emissary-core/src/primitives/destination.rs
+++ b/emissary-core/src/primitives/destination.rs
@@ -281,6 +281,16 @@ impl Destination {
     pub fn serialized(&self) -> &Bytes {
         &self.serialized
     }
+
+    /// Create random [`Destination`] for testing.
+    #[cfg(test)]
+    pub fn random() -> (Self, crate::crypto::SigningPrivateKey) {
+        let signing_key = crate::crypto::SigningPrivateKey::random(rand::thread_rng());
+        (
+            Self::new::<crate::runtime::mock::MockRuntime>(signing_key.public()),
+            signing_key,
+        )
+    }
 }
 
 #[cfg(test)]

--- a/emissary-core/src/sam/pending/session.rs
+++ b/emissary-core/src/sam/pending/session.rs
@@ -27,6 +27,7 @@ use crate::{
         parser::{DestinationContext, SessionKind},
         session::{SamSessionCommand, SamSessionCommandRecycle},
         socket::SamSocket,
+        SubSessionCommand,
     },
     tunnel::{TunnelPoolEvent, TunnelPoolHandle},
 };
@@ -85,6 +86,9 @@ pub struct SamSessionContext<R: Runtime> {
     /// SAMv3 socket.
     pub socket: SamSocket<R>,
 
+    /// TX channel for sending sub-session commands.
+    pub sub_session_tx: Option<Sender<SubSessionCommand>>,
+
     /// Tunnel pool handle.
     pub tunnel_pool_handle: TunnelPoolHandle,
 }
@@ -134,6 +138,9 @@ pub struct PendingSamSession<R: Runtime> {
     /// SAMv3 socket associated with the session.
     socket: SamSocket<R>,
 
+    /// TX channel for sending sub-session commands.
+    sub_session_tx: Option<Sender<SubSessionCommand>>,
+
     /// Tunnel pool build future.
     ///
     /// Resolves to a `TunnelPoolHandle` once the pool has been built.
@@ -155,6 +162,7 @@ impl<R: Runtime> PendingSamSession<R> {
         address_book: Option<Arc<dyn AddressBook>>,
         event_handle: EventHandle<R>,
         profile_storage: ProfileStorage<R>,
+        sub_session_tx: Option<Sender<SubSessionCommand>>,
     ) -> Self {
         Self {
             address_book,
@@ -170,6 +178,7 @@ impl<R: Runtime> PendingSamSession<R> {
             session_id,
             session_kind,
             socket,
+            sub_session_tx,
             tunnel_pool_future,
         }
     }
@@ -267,6 +276,7 @@ impl<R: Runtime> PendingSamSession<R> {
             session_id: self.session_id,
             session_kind: self.session_kind,
             socket: self.socket,
+            sub_session_tx: self.sub_session_tx,
             tunnel_pool_handle,
         })
     }

--- a/emissary-core/src/sam/protocol/datagram/mod.rs
+++ b/emissary-core/src/sam/protocol/datagram/mod.rs
@@ -23,7 +23,6 @@ use crate::{
     primitives::Destination,
     protocol::Protocol,
     runtime::Runtime,
-    sam::parser::SessionKind,
 };
 
 use bytes::{BufMut, BytesMut};
@@ -34,6 +33,9 @@ use thingbuf::mpsc::Sender;
 use alloc::{format, string::String, vec::Vec};
 use core::marker::PhantomData;
 
+/// Logging target for the file.
+const LOG_TARGET: &str = "emissary::datagram";
+
 /// Datagram manager.
 pub struct DatagramManager<R: Runtime> {
     /// TX channel which can be used to send datagrams to clients.
@@ -42,11 +44,8 @@ pub struct DatagramManager<R: Runtime> {
     /// Local destination.
     destination: Destination,
 
-    /// Session options.
-    options: HashMap<String, String>,
-
-    /// Session kind.
-    session_kind: SessionKind,
+    /// Listeners.
+    listeners: HashMap<u16, u16>,
 
     /// Signing key.
     signing_key: SigningPrivateKey,
@@ -62,22 +61,30 @@ impl<R: Runtime> DatagramManager<R> {
         datagram_tx: Sender<(u16, Vec<u8>)>,
         options: HashMap<String, String>,
         signing_key: SigningPrivateKey,
-        session_kind: SessionKind,
     ) -> Self {
         Self {
             datagram_tx,
             destination,
-            options,
-            session_kind,
+            listeners: {
+                let port = options.get("PORT").and_then(|port| port.parse::<u16>().ok());
+                let dst_port = options.get("FROM_PORT").and_then(|port| port.parse::<u16>().ok());
+
+                // `port` may not exist if `DatagramManager` is owned by a primary session
+                port.map_or_else(HashMap::new, |port| {
+                    HashMap::from_iter([(dst_port.unwrap_or(0), port)])
+                })
+            },
             signing_key,
             _runtime: Default::default(),
         }
     }
 
     /// Make repliable datagram.
-    pub fn make_datagram(&mut self, datagram: Vec<u8>) -> Vec<u8> {
-        match self.session_kind {
-            SessionKind::Datagram => {
+    ///
+    /// Caller must ensure to call this function with correct `protocol`.
+    pub fn make_datagram(&mut self, protocol: Protocol, datagram: Vec<u8>) -> Vec<u8> {
+        match protocol {
+            Protocol::Datagram => {
                 let signature = self.signing_key.sign(&datagram);
                 let destination = self.destination.serialize();
 
@@ -89,8 +96,8 @@ impl<R: Runtime> DatagramManager<R> {
 
                 out.to_vec()
             }
-            SessionKind::Anonymous => datagram,
-            SessionKind::Stream => unreachable!(), // TODO: technically not unreachable
+            Protocol::Anonymous => datagram,
+            Protocol::Streaming => unreachable!(),
         }
     }
 
@@ -102,6 +109,15 @@ impl<R: Runtime> DatagramManager<R> {
             protocol,
             src_port,
         } = payload;
+
+        let Some(port) = self.listeners.get(&dst_port) else {
+            tracing::warn!(
+                target: LOG_TARGET,
+                ?dst_port,
+                "no datagram listener for destination port",
+            );
+            return Err(Error::InvalidState);
+        };
 
         match protocol {
             Protocol::Datagram => {
@@ -116,11 +132,8 @@ impl<R: Runtime> DatagramManager<R> {
                     verifying_key => verifying_key.verify(rest, signature)?,
                 }
 
-                // TODO: ensure there is a listener in `src_port`
-                let port = self.options.get("PORT").ok_or(Error::InvalidState)?;
-
                 let info = format!(
-                    "{} FROM_PORT={dst_port} TO_PORT={src_port}\n",
+                    "{} FROM_PORT={src_port} TO_PORT={dst_port}\n",
                     base64_encode(destination.serialize())
                 );
 
@@ -130,21 +143,238 @@ impl<R: Runtime> DatagramManager<R> {
                 out.put_slice(info);
                 out.put_slice(rest);
 
-                let _ = self
-                    .datagram_tx
-                    .try_send((port.parse::<u16>().expect("to succeed"), out.to_vec()));
+                let _ = self.datagram_tx.try_send((*port, out.to_vec()));
 
                 Ok(())
             }
             Protocol::Anonymous => {
-                let port = self.options.get("PORT").ok_or(Error::InvalidState)?;
-
-                let _ =
-                    self.datagram_tx.try_send((port.parse::<u16>().expect("to succeed"), payload));
+                let _ = self.datagram_tx.try_send((*port, payload));
 
                 Ok(())
             }
             Protocol::Streaming => unreachable!(),
         }
+    }
+
+    /// Attempt add datagram listener.
+    ///
+    /// The SAMv3 `PORT` and `FROM_PORT` are parsed from `options` and if a listener for the same
+    /// port already exists in [`DatagramManager`], the listener is not added to the set of
+    /// listeners and `Err(())` is returned.
+    ///
+    /// If `PORT` doesn't exist in `options`, `Err(())` is return and if `FROM_PORT` is not
+    /// specified in `options`, it defaults to `0`.
+    pub fn add_listener(&mut self, options: HashMap<String, String>) -> Result<(), ()> {
+        let dst_port = options
+            .get("FROM_PORT")
+            .and_then(|port| port.parse::<u16>().ok())
+            .unwrap_or(0u16);
+        let port = options.get("PORT").ok_or_else(|| {
+            tracing::warn!(
+                target: LOG_TARGET,
+                ?options,
+                "tried to register datagram listener without specifying `PORT`",
+            );
+        })?;
+
+        if let Some(port) = self.listeners.get(&dst_port) {
+            tracing::warn!(
+                target: LOG_TARGET,
+                ?port,
+                ?dst_port,
+                "listener for the specified destination port already exists",
+            );
+            return Err(());
+        }
+
+        match port.parse::<u16>() {
+            Err(error) => {
+                tracing::warn!(
+                    target: LOG_TARGET,
+                    ?port,
+                    ?error,
+                    "invalid `PORT` for datagram listener",
+                );
+                Err(())
+            }
+            Ok(port) => {
+                self.listeners.insert(dst_port, port);
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::mock::MockRuntime;
+    use thingbuf::mpsc::channel;
+
+    #[test]
+    fn create_datagram_session() {
+        let (destination, signing_key) = Destination::random();
+        let (tx, _rx) = channel(16);
+
+        let manager = DatagramManager::<MockRuntime>::new(
+            destination,
+            tx,
+            HashMap::from_iter([("PORT".to_string(), "8888".to_string())]),
+            signing_key,
+        );
+
+        assert_eq!(manager.listeners.get(&0), Some(&8888));
+    }
+
+    #[test]
+    fn create_datagram_session_with_dst_port() {
+        let (destination, signing_key) = Destination::random();
+        let (tx, _rx) = channel(16);
+
+        let manager = DatagramManager::<MockRuntime>::new(
+            destination,
+            tx,
+            HashMap::from_iter([
+                ("PORT".to_string(), "1337".to_string()),
+                ("FROM_PORT".to_string(), "8889".to_string()),
+            ]),
+            signing_key,
+        );
+
+        assert_eq!(manager.listeners.get(&8889), Some(&1337));
+    }
+
+    #[test]
+    fn create_primary_session() {
+        let (destination, signing_key) = Destination::random();
+        let (tx, _rx) = channel(16);
+
+        let manager =
+            DatagramManager::<MockRuntime>::new(destination, tx, HashMap::new(), signing_key);
+
+        assert!(manager.listeners.is_empty());
+    }
+
+    #[test]
+    fn receive_datagram_on_non_existent_port() {
+        let (destination, signing_key) = Destination::random();
+        let (tx, _rx) = channel(16);
+
+        let manager =
+            DatagramManager::<MockRuntime>::new(destination, tx, HashMap::new(), signing_key);
+
+        match manager.on_datagram(I2cpPayload {
+            dst_port: 0,
+            payload: vec![1, 3, 3, 7],
+            protocol: Protocol::Datagram,
+            src_port: 0,
+        }) {
+            Err(Error::InvalidState) => {}
+            _ => panic!("invalid result"),
+        }
+    }
+
+    #[test]
+    fn add_listener() {
+        let (destination, signing_key) = Destination::random();
+        let (tx, _rx) = channel(16);
+
+        let mut manager =
+            DatagramManager::<MockRuntime>::new(destination, tx, HashMap::new(), signing_key);
+
+        assert!(manager
+            .add_listener(HashMap::from_iter([
+                ("PORT".to_string(), "2048".to_string()),
+                ("FROM_PORT".to_string(), "7777".to_string()),
+            ]))
+            .is_ok());
+        assert_eq!(manager.listeners.get(&7777), Some(&2048));
+    }
+
+    #[test]
+    fn add_listener_with_default_port() {
+        let (destination, signing_key) = Destination::random();
+        let (tx, _rx) = channel(16);
+
+        let mut manager =
+            DatagramManager::<MockRuntime>::new(destination, tx, HashMap::new(), signing_key);
+
+        assert!(manager
+            .add_listener(HashMap::from_iter([(
+                "PORT".to_string(),
+                "2048".to_string()
+            ),]))
+            .is_ok());
+        assert_eq!(manager.listeners.get(&0), Some(&2048));
+    }
+
+    #[test]
+    fn add_listener_invalid_port() {
+        let (destination, signing_key) = Destination::random();
+        let (tx, _rx) = channel(16);
+
+        let mut manager =
+            DatagramManager::<MockRuntime>::new(destination, tx, HashMap::new(), signing_key);
+
+        assert!(manager
+            .add_listener(HashMap::from_iter([(
+                "PORT".to_string(),
+                "hello, world".to_string()
+            ),]))
+            .is_err());
+    }
+
+    #[test]
+    fn add_listener_port_missing() {
+        let (destination, signing_key) = Destination::random();
+        let (tx, _rx) = channel(16);
+
+        let mut manager =
+            DatagramManager::<MockRuntime>::new(destination, tx, HashMap::new(), signing_key);
+
+        assert!(manager
+            .add_listener(HashMap::from_iter([(
+                "FROM_PORT".to_string(),
+                "1337".to_string()
+            ),]))
+            .is_err());
+    }
+
+    #[test]
+    fn add_listener_invalid_src_port() {
+        let (destination, signing_key) = Destination::random();
+        let (tx, _rx) = channel(16);
+
+        let mut manager =
+            DatagramManager::<MockRuntime>::new(destination, tx, HashMap::new(), signing_key);
+
+        assert!(manager
+            .add_listener(HashMap::from_iter([
+                ("PORT".to_string(), "2048".to_string()),
+                ("FROM_PORT".to_string(), "hello, world".to_string()),
+            ]))
+            .is_ok());
+    }
+
+    #[test]
+    fn add_listener_src_port_already_taken() {
+        let (destination, signing_key) = Destination::random();
+        let (tx, _rx) = channel(16);
+
+        let mut manager = DatagramManager::<MockRuntime>::new(
+            destination,
+            tx,
+            HashMap::from_iter([("PORT".to_string(), "1337".to_string())]),
+            signing_key,
+        );
+        assert_eq!(manager.listeners.get(&0), Some(&1337));
+
+        assert!(manager
+            .add_listener(HashMap::from_iter([(
+                "PORT".to_string(),
+                "2048".to_string()
+            ),]))
+            .is_err());
+        assert_eq!(manager.listeners.get(&0), Some(&1337));
     }
 }

--- a/emissary-core/src/transport/ntcp2/session/mod.rs
+++ b/emissary-core/src/transport/ntcp2/session/mod.rs
@@ -392,7 +392,7 @@ impl<R: Runtime> SessionManager<R> {
                 ))
             }
             Err(error) => {
-                tracing::warn!(
+                tracing::debug!(
                     target: LOG_TARGET,
                     ?error,
                     "failed to accept session",

--- a/emissary-core/src/transport/ntcp2/session/responder.rs
+++ b/emissary-core/src/transport/ntcp2/session/responder.rs
@@ -353,7 +353,7 @@ impl Responder {
             match MessageBlock::parse(&router_info) {
                 Some(MessageBlock::RouterInfo { router_info, .. }) =>
                     RouterInfo::parse(router_info).ok_or_else(|| {
-                        tracing::warn!(
+                        tracing::debug!(
                             target: LOG_TARGET,
                             "received malformed `RouterInfo` message block"
                         );


### PR DESCRIPTION
Multiple streams cannot call `STREAM FORWARD` because `StreamManager` in its current form cannot handle those. Not sure if there's any use case for it either.

Currently a single repliable/anonymous datagram session can be registered per primary session because `yosemite` doesn't support source/destination port configuration so the datagram sessions default to using `0` as their port and `DatagramManager` only allows a single listener per port. `yosemite` issues are tracked [here](https://github.com/altonen/yosemite/issues/9) and [here](https://github.com/altonen/yosemite/issues/10)

Resolves #57