### PR TITLE
ssu2: Fix `SessionCreated` custom network ID test

### DIFF
--- a/emissary-core/src/transport/ssu2/message/handshake.rs
+++ b/emissary-core/src/transport/ssu2/message/handshake.rs
@@ -945,6 +945,7 @@ mod tests {
                     .with_ephemeral_key(EphemeralPrivateKey::random(MockRuntime::rng()).public())
                     .build::<MockRuntime>();
 
+                pkt.encrypt_payload(&[1u8; 32], 1337, &[0u8; 32]);
                 pkt.encrypt_header([1u8; 32], [1u8; 32]);
                 pkt.build().to_vec()
             };
@@ -968,6 +969,7 @@ mod tests {
                     .with_ephemeral_key(EphemeralPrivateKey::random(MockRuntime::rng()).public())
                     .build::<MockRuntime>();
 
+                pkt.encrypt_payload(&[1u8; 32], 1337, &[0u8; 32]);
                 pkt.encrypt_header([1u8; 32], [1u8; 32]);
                 pkt.build().to_vec()
             };


### PR DESCRIPTION
The payload was not encrypted, meaning it didn't have the Poly13055 authentication tag and the test would fail as the length of the packet relied entirely on the length of the randomly-generated padding

Resolves #176 