### PR TITLE
cli: Add Base64 encoding/decoding as built-in router commands

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -21,6 +21,7 @@ export default defineConfig({
           { text: "Eepsites", link: "/eepsite.md" },
           { text: "Torrents", link: "/torrents.md" },
           { text: "IRC and Email", link: "/irc-email.md" },
+          { text: "Built-in tools", link: "/tooling.md" },
         ]
       },
     ],

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -1,0 +1,31 @@
+---
+outline: deep
+---
+
+# Built-in tools
+
+`emissary-cli` includes built-in tools inspired by [i2pd-tools](https://github.com/PurpleI2P/i2pd-tools/), available as subcommands of the router.
+
+## Base64 encoding and decoding
+
+`base64-encode` and `base64-decode` commands allow encoding and decoding strings and files using the I2P Base64 alphabet.
+
+### Examples
+
+Base64-encode a binary key file, reading from stdin and writing to `key.b64` file:
+
+```bash
+emissary-cli base64-encode < key.dat > key.b64
+```
+
+Base64-decode a string and write the output to stdout:
+
+```bash
+emissary-cli base64-decode -s aGVsbG8sIHdvcmxkIQ==
+```
+
+Base64-decode a file and write the output to a file:
+
+```bash
+emissary-cli base64-decode -f key.b64 -o key.dat
+```

--- a/emissary-cli/src/cli.rs
+++ b/emissary-cli/src/cli.rs
@@ -18,7 +18,7 @@
 
 use clap::{Args, Parser};
 
-use crate::config::Theme;
+use crate::{config::Theme, tools::RouterCommand};
 
 #[derive(Args)]
 pub struct TunnelOptions {
@@ -242,4 +242,10 @@ pub struct Arguments {
     /// Port forwarding options.
     #[clap(flatten)]
     pub router_ui: RouterUiOptions,
+
+    /// Optional router command.
+    ///
+    /// Router is started normally if no command is specified.
+    #[command(subcommand)]
+    pub command: Option<RouterCommand>,
 }

--- a/emissary-cli/src/config.rs
+++ b/emissary-cli/src/config.rs
@@ -1268,6 +1268,7 @@ mod tests {
     fn make_arguments() -> Arguments {
         Arguments {
             base_path: None,
+            command: None,
             log: None,
             #[cfg(any(
                 all(feature = "native-ui", not(feature = "web-ui")),

--- a/emissary-cli/src/tools/base64.rs
+++ b/emissary-cli/src/tools/base64.rs
@@ -1,0 +1,160 @@
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! Base64 encode/decode files and strings using the I2P Base64 alphabet.
+
+use anyhow::anyhow;
+use emissary_core::crypto::{base64_decode, base64_encode};
+
+use std::{
+    fs,
+    io::{self, Read, Write},
+};
+
+/// Base64-encode data from `string`, `file` or stdin based on which is specified and write the
+/// Base64-encoded string to `output` (if specified) or to stdout.
+pub fn encode(
+    string: Option<String>,
+    file: Option<String>,
+    output: Option<String>,
+) -> anyhow::Result<()> {
+    // clap has ensured that only `string` or `file` is `Some` but not both
+    let encoded = match (string, file) {
+        (Some(string), _) => base64_encode(string),
+        (_, Some(path)) => base64_encode(fs::read(path)?),
+        (None, None) => {
+            let mut buf = Vec::new();
+            io::stdin().read_to_end(&mut buf)?;
+            base64_encode(buf)
+        }
+    };
+
+    if let Some(out) = output {
+        fs::write(out, encoded)?;
+    } else {
+        io::stdout().write_all(encoded.as_ref())?;
+    }
+
+    Ok(())
+}
+
+/// Base64-decode data from `string`, `file` or stdin based on which is specified and write the
+/// Base64-encoded string to `output` (if specified) or to stdout.
+pub fn decode(
+    string: Option<String>,
+    file: Option<String>,
+    output: Option<String>,
+) -> anyhow::Result<()> {
+    // clap has ensured that only `string` or `file` is `Some` but not both
+    let decoded = match (string, file) {
+        (Some(string), _) => base64_decode(string),
+        (_, Some(path)) => base64_decode(fs::read(path)?),
+        (None, None) => {
+            let mut buf = Vec::new();
+            io::stdin().read_to_end(&mut buf)?;
+            base64_decode(buf)
+        }
+    }
+    .ok_or_else(|| anyhow!("failed to base64-decode input"))?;
+
+    if let Some(out) = output {
+        fs::write(out, decoded)?;
+    } else {
+        io::stdout().write_all(decoded.as_ref())?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn encode_and_decode_string() {
+        let dir = tempdir().unwrap();
+        let output = dir.path().join("output.txt").as_path().to_str().unwrap().to_string();
+
+        encode(
+            Some("hello, world!".to_string()),
+            None,
+            Some(output.clone()),
+        )
+        .unwrap();
+
+        // ensure the string has been encoded correctly
+        let contents = fs::read_to_string(&output).unwrap();
+        assert_eq!(base64_encode("hello, world!"), contents);
+
+        // ensure the string decodes to same input
+        let decode_output =
+            dir.path().join("decode_output1.txt").as_path().to_str().unwrap().to_string();
+        decode(Some(contents), None, Some(decode_output.clone())).unwrap();
+
+        let decoded = fs::read_to_string(decode_output).unwrap();
+        assert_eq!(decoded.as_str(), "hello, world!");
+    }
+
+    #[test]
+    fn encode_and_decode_file() {
+        let dir = tempdir().unwrap();
+        let input = dir.path().join("input.txt").as_path().to_str().unwrap().to_string();
+        let output = dir.path().join("output.txt").as_path().to_str().unwrap().to_string();
+        fs::write(&input, "goodbye, world!").unwrap();
+
+        encode(None, Some(input), Some(output.clone())).unwrap();
+
+        // ensure the string has been encoded correctly
+        let contents = fs::read_to_string(&output).unwrap();
+        assert_eq!(base64_encode("goodbye, world!"), contents);
+
+        // ensure the file contents decode to same input
+        let decode_output =
+            dir.path().join("decode_output1.txt").as_path().to_str().unwrap().to_string();
+        decode(None, Some(output), Some(decode_output.clone())).unwrap();
+
+        let decoded = fs::read_to_string(decode_output).unwrap();
+        assert_eq!(decoded.as_str(), "goodbye, world!");
+    }
+
+    #[test]
+    fn encode_file_doesnt_exist() {
+        let dir = tempdir().unwrap();
+        let input = dir.path().join("input.txt").as_path().to_str().unwrap().to_string();
+        let output = dir.path().join("output.txt").as_path().to_str().unwrap().to_string();
+
+        assert!(encode(None, Some(input), Some(output.clone())).is_err());
+    }
+
+    #[test]
+    fn decode_not_base64() {
+        let dir = tempdir().unwrap();
+        let input = dir.path().join("input.txt").as_path().to_str().unwrap().to_string();
+        let output = dir.path().join("output.txt").as_path().to_str().unwrap().to_string();
+        fs::write(&input, "goodbye, world!").unwrap();
+
+        assert!(decode(
+            Some("hello, world!".to_string()),
+            None,
+            Some(output.clone())
+        )
+        .is_err());
+        assert!(decode(None, Some(input), Some(output.clone())).is_err());
+    }
+}

--- a/emissary-cli/src/tools/base64.rs
+++ b/emissary-cli/src/tools/base64.rs
@@ -54,7 +54,7 @@ pub fn encode(
 }
 
 /// Base64-decode data from `string`, `file` or stdin based on which is specified and write the
-/// Base64-encoded string to `output` (if specified) or to stdout.
+/// Base64-decoded string to `output` (if specified) or to stdout.
 pub fn decode(
     string: Option<String>,
     file: Option<String>,

--- a/emissary-cli/src/tools/mod.rs
+++ b/emissary-cli/src/tools/mod.rs
@@ -1,0 +1,77 @@
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use clap::{ArgGroup, Subcommand};
+
+pub mod base64;
+
+/// Router commands.
+///
+/// These are inspired by [`i2pd-tools`](https://github.com/PurpleI2P/i2pd-tools/).
+#[derive(Subcommand)]
+pub enum RouterCommand {
+    /// Base64-encode data using the I2P Base64 alphabet.
+    ///
+    /// Input is read from stdin if `string` and `file` are not specified.
+    ///
+    /// Output is written to stdout if `output` is not specified.
+    #[command(group(
+        ArgGroup::new("input")
+            .args(&["string", "file"])
+            .required(false)
+            .multiple(false),
+    ))]
+    Base64Encode {
+        /// Input string to encode.
+        #[arg(short = 's', long, value_name = "STRING")]
+        string: Option<String>,
+
+        /// Input file to encode.
+        #[arg(short = 'f', long, value_name = "FILE")]
+        file: Option<String>,
+
+        /// Path to output file where the Base64-encoded string is written to.
+        #[arg(short = 'o', long, value_name = "OUTPUT")]
+        output: Option<String>,
+    },
+
+    /// Base64-decode data using the I2P Base64 alphabet.
+    ///
+    /// Input is read from stdin if `string` and `file` are not specified.
+    ///
+    /// Output is written to stdout if `output` is not specified.
+    #[command(group(
+        ArgGroup::new("input")
+            .args(&["string", "file"])
+            .required(false)
+            .multiple(false),
+    ))]
+    Base64Decode {
+        /// Input string to decode.
+        #[arg(short = 's', long, value_name = "STRING")]
+        string: Option<String>,
+
+        /// Input file to decode.
+        #[arg(short = 'f', long, value_name = "FILE")]
+        file: Option<String>,
+
+        /// Path to output file where the Base64-decoded string is written to.
+        #[arg(short = 'o', long, value_name = "OUTPUT")]
+        output: Option<String>,
+    },
+}


### PR DESCRIPTION
Introduce `RouterCommand` which allows extending `emissary-cli` with tooling-related functionality, such as Base64 encoding/decoding or key generation.

The router is still started normally as `emissary-cli` but now the binary accepts an optional command, e.g., `emissary-cli base64-encode` which, instead of starting the router, allows accessing I2P-related tooling.