### PR TITLE
streaming: Send Base64-encoded destination to non-silent listeners

### DIFF
--- a/emissary-core/src/sam/protocol/streaming/packet.rs
+++ b/emissary-core/src/sam/protocol/streaming/packet.rs
@@ -486,7 +486,7 @@ impl FlagsBuilder<'_> {
     }
 
     /// Specify that local destination ID is included.
-    pub fn with_from_included(mut self, destination: Destination) -> Self {
+    pub fn with_from_included(mut self, destination: &Destination) -> Self {
         self.options_len += destination.serialized_len();
         self.destination = Some(destination.serialize());
         self.flags |= 1 << 5;
@@ -666,7 +666,7 @@ impl<'a> PacketBuilder<'a> {
     }
 
     /// Specify that local destination ID is included.
-    pub fn with_from_included(mut self, destination: Destination) -> Self {
+    pub fn with_from_included(mut self, destination: &Destination) -> Self {
         self.flags_builder = self.flags_builder.with_from_included(destination);
         self
     }
@@ -820,7 +820,7 @@ mod tests {
 
         let (flags, options) = FlagsBuilder::default()
             .with_synchronize()
-            .with_from_included(destination.clone())
+            .with_from_included(&destination)
             .with_signature()
             .with_max_packet_size(1337)
             .with_delay_requested(750)
@@ -877,7 +877,7 @@ mod tests {
             .with_reset()
             .with_echo()
             .with_no_ack()
-            .with_from_included(destination.clone())
+            .with_from_included(&destination)
             .with_signature()
             .with_max_packet_size(1338)
             .with_delay_requested(800)
@@ -919,7 +919,7 @@ mod tests {
             .with_signature()
             .with_replay_protection(&recv_destination_id)
             .with_resend_delay(128)
-            .with_from_included(destination.clone())
+            .with_from_included(&destination)
             .with_payload(&payload)
             .build_and_sign(&signing_key);
 
@@ -1012,7 +1012,7 @@ mod tests {
             .with_synchronize()
             .with_replay_protection(&recv_destination_id)
             .with_resend_delay(128)
-            .with_from_included(destination.clone())
+            .with_from_included(&destination)
             .with_payload(&payload)
             .build_and_sign(&signing_key);
     }
@@ -1033,7 +1033,7 @@ mod tests {
             .with_signature()
             .with_replay_protection(&recv_destination_id)
             .with_resend_delay(128)
-            .with_from_included(destination.clone())
+            .with_from_included(&destination)
             .with_payload(&payload)
             .build();
     }

--- a/emissary-core/src/sam/protocol/streaming/stream/active.rs
+++ b/emissary-core/src/sam/protocol/streaming/stream/active.rs
@@ -588,7 +588,7 @@ impl<R: Runtime> Stream<R> {
                 let send_stream_id = R::rng().next_u32();
                 let packet = PacketBuilder::new(send_stream_id)
                     .with_send_stream_id(recv_stream_id)
-                    .with_from_included(destination.clone())
+                    .with_from_included(&destination)
                     .with_seq_nro(0)
                     .with_synchronize()
                     .with_signature()
@@ -799,7 +799,7 @@ impl<R: Runtime> Stream<R> {
                 .with_send_stream_id(self.recv_stream_id)
                 .with_seq_nro(0)
                 .with_synchronize()
-                .with_from_included(self.destination.clone())
+                .with_from_included(&self.destination)
                 .with_signature()
                 .build_and_sign(&self.signing_key);
 
@@ -1089,7 +1089,7 @@ impl<R: Runtime> Stream<R> {
             .with_ack_through(self.inbound_context.seq_nro)
             .with_seq_nro(seq_nro)
             .with_close()
-            .with_from_included(self.destination.clone())
+            .with_from_included(&self.destination)
             .with_signature()
             .build_and_sign(&self.signing_key)
             .to_vec();
@@ -1425,7 +1425,7 @@ impl<R: Runtime> Future for Stream<R> {
             let packet = if this.inbound_context.can_close() {
                 builder
                     .with_close()
-                    .with_from_included(this.destination.clone())
+                    .with_from_included(&this.destination)
                     .with_signature()
                     .build_and_sign(&this.signing_key)
             } else {

--- a/emissary-core/src/sam/protocol/streaming/stream/pending.rs
+++ b/emissary-core/src/sam/protocol/streaming/stream/pending.rs
@@ -68,6 +68,9 @@ pub struct PendingStream<R: Runtime> {
     /// Destination ID of the remote peer.
     pub destination_id: DestinationId,
 
+    /// Destination of remote peer.
+    pub remote_destination: Destination,
+
     /// When was the stream established.
     pub established: R::Instant,
 
@@ -91,8 +94,8 @@ impl<R: Runtime> PendingStream<R> {
     ///
     /// `syn_payload` is the payload contained within the `SYN` message and may be empty.
     pub fn new(
-        destination: Destination,
-        remote_destination_id: DestinationId,
+        destination: &Destination,
+        remote_destination: Destination,
         recv_stream_id: u32,
         syn_payload: Vec<u8>,
         signing_key: &SigningPrivateKey,
@@ -109,7 +112,8 @@ impl<R: Runtime> PendingStream<R> {
 
         (
             Self {
-                destination_id: remote_destination_id,
+                destination_id: remote_destination.id(),
+                remote_destination,
                 established: R::now(),
                 packets: match syn_payload.is_empty() {
                     true => VecDeque::new(),
@@ -211,8 +215,8 @@ mod tests {
     fn ignore_duplicate_ack() {
         let signing_key = SigningPrivateKey::from_bytes(&[0u8; 32]).unwrap();
         let (mut stream, _) = PendingStream::<NoopRuntime>::new(
-            Destination::new::<NoopRuntime>(signing_key.public()),
-            DestinationId::random(),
+            &Destination::new::<NoopRuntime>(signing_key.public()),
+            Destination::random().0,
             1337u32,
             vec![],
             &SigningPrivateKey::random(NoopRuntime::rng()),
@@ -234,8 +238,8 @@ mod tests {
     fn destroy_stream_on_close() {
         let signing_key = SigningPrivateKey::from_bytes(&[0u8; 32]).unwrap();
         let (mut stream, _) = PendingStream::<NoopRuntime>::new(
-            Destination::new::<NoopRuntime>(signing_key.public()),
-            DestinationId::random(),
+            &Destination::new::<NoopRuntime>(signing_key.public()),
+            Destination::random().0,
             1337u32,
             vec![],
             &SigningPrivateKey::random(NoopRuntime::rng()),
@@ -258,8 +262,8 @@ mod tests {
     fn destroy_stream_on_reset() {
         let signing_key = SigningPrivateKey::from_bytes(&[0u8; 32]).unwrap();
         let (mut stream, _) = PendingStream::<NoopRuntime>::new(
-            Destination::new::<NoopRuntime>(signing_key.public()),
-            DestinationId::random(),
+            &Destination::new::<NoopRuntime>(signing_key.public()),
+            Destination::random().0,
             1337u32,
             vec![],
             &SigningPrivateKey::random(NoopRuntime::rng()),
@@ -282,8 +286,8 @@ mod tests {
     fn buffer_data_correctly() {
         let signing_key = SigningPrivateKey::from_bytes(&[0u8; 32]).unwrap();
         let (mut stream, _) = PendingStream::<NoopRuntime>::new(
-            Destination::new::<NoopRuntime>(signing_key.public()),
-            DestinationId::random(),
+            &Destination::new::<NoopRuntime>(signing_key.public()),
+            Destination::random().0,
             1337u32,
             vec![],
             &SigningPrivateKey::random(NoopRuntime::rng()),
@@ -328,8 +332,8 @@ mod tests {
     fn ignore_invalid_packets() {
         let signing_key = SigningPrivateKey::from_bytes(&[0u8; 32]).unwrap();
         let (mut stream, _) = PendingStream::<NoopRuntime>::new(
-            Destination::new::<NoopRuntime>(signing_key.public()),
-            DestinationId::random(),
+            &Destination::new::<NoopRuntime>(signing_key.public()),
+            Destination::random().0,
             1337u32,
             vec![],
             &SigningPrivateKey::random(NoopRuntime::rng()),
@@ -345,8 +349,8 @@ mod tests {
     fn receive_window_full() {
         let signing_key = SigningPrivateKey::from_bytes(&[0u8; 32]).unwrap();
         let (mut stream, _) = PendingStream::<NoopRuntime>::new(
-            Destination::new::<NoopRuntime>(signing_key.public()),
-            DestinationId::random(),
+            &Destination::new::<NoopRuntime>(signing_key.public()),
+            Destination::random().0,
             1337u32,
             vec![],
             &SigningPrivateKey::random(NoopRuntime::rng()),
@@ -393,8 +397,8 @@ mod tests {
     fn syn_payload_not_empty() {
         let signing_key = SigningPrivateKey::from_bytes(&[0u8; 32]).unwrap();
         let (mut stream, _) = PendingStream::<NoopRuntime>::new(
-            Destination::new::<NoopRuntime>(signing_key.public()),
-            DestinationId::random(),
+            &Destination::new::<NoopRuntime>(signing_key.public()),
+            Destination::random().0,
             1337u32,
             vec![1, 2, 3, 4],
             &SigningPrivateKey::random(NoopRuntime::rng()),


### PR DESCRIPTION
Resolves #229 