### PR TITLE
ssu2: Terminate inbound connection if outbound connection is pending

### DIFF
--- a/emissary-core/src/transport/ssu2/session/active/mod.rs
+++ b/emissary-core/src/transport/ssu2/session/active/mod.rs
@@ -644,6 +644,7 @@ impl<R: Runtime> Ssu2Session<R> {
             rx: self.pkt_rx,
             send_key_ctx: self.send_key_ctx,
             tx: self.pkt_tx,
+            k_session_confirmed: None,
         }
     }
 }

--- a/emissary-core/src/transport/ssu2/session/pending/inbound.rs
+++ b/emissary-core/src/transport/ssu2/session/pending/inbound.rs
@@ -236,7 +236,7 @@ impl<R: Runtime> InboundSsu2Session<R> {
             ?src_id,
             ?pkt_num,
             ?token,
-            "handle `TokenRequest`",
+            "handle TokenRequest",
         );
 
         // retry messages are not retransmitted
@@ -247,7 +247,7 @@ impl<R: Runtime> InboundSsu2Session<R> {
                 ?src_id,
                 ?address,
                 ?error,
-                "failed to send `Retry`",
+                "failed to send Retry",
             );
         }
 
@@ -324,7 +324,7 @@ impl<R: Runtime> InboundSsu2Session<R> {
                         remote_src_id = ?src_id,
                         ?pkt_num,
                         ?token,
-                        "received unexpected `TokenRequest`",
+                        "received unexpected TokenRequest",
                     );
 
                     if let Err(error) = self.pkt_tx.try_send(Packet {
@@ -338,7 +338,7 @@ impl<R: Runtime> InboundSsu2Session<R> {
                             remote_src_id = ?src_id,
                             address = ?self.address,
                             ?error,
-                            "failed to send `Retry`",
+                            "failed to send Retry",
                         );
                     }
 
@@ -351,7 +351,7 @@ impl<R: Runtime> InboundSsu2Session<R> {
                         dst_id = ?self.dst_id,
                         src_id = ?self.src_id,
                         ?kind,
-                        "unexpected message, expected `SessionRequest`",
+                        "unexpected message, expected SessionRequest",
                     );
                     return Err(Ssu2Error::UnexpectedMessage);
                 }
@@ -364,7 +364,7 @@ impl<R: Runtime> InboundSsu2Session<R> {
             ?pkt_num,
             ?token,
             ?recv_token,
-            "handle `SessionRequest`",
+            "handle SessionRequest",
         );
 
         if token != recv_token {
@@ -406,7 +406,7 @@ impl<R: Runtime> InboundSsu2Session<R> {
                 dst_id = ?self.dst_id,
                 src_id = ?self.src_id,
                 ?error,
-                "malformed `SessionRequest` payload",
+                "malformed SessionRequest payload",
             );
             debug_assert!(false);
             return Err(Ssu2Error::Malformed);
@@ -449,7 +449,7 @@ impl<R: Runtime> InboundSsu2Session<R> {
                 src_id = ?self.src_id,
                 address = ?self.address,
                 ?error,
-                "failed to send `SessionCreated`",
+                "failed to send SessionCreated",
             );
         }
 
@@ -493,7 +493,7 @@ impl<R: Runtime> InboundSsu2Session<R> {
                     dst_id = ?self.dst_id,
                     src_id = ?self.src_id,
                     ?kind,
-                    "unexpected message, expected `SessionConfirmed`",
+                    "unexpected message, expected SessionConfirmed",
                 );
 
                 self.state = PendingSessionState::AwaitingSessionConfirmed {
@@ -509,7 +509,7 @@ impl<R: Runtime> InboundSsu2Session<R> {
             target: LOG_TARGET,
             dst_id = ?self.dst_id,
             src_id = ?self.src_id,
-            "handle `SessionConfirmed`",
+            "handle SessionConfirmed",
         );
 
         // MixHash(header)
@@ -538,7 +538,7 @@ impl<R: Runtime> InboundSsu2Session<R> {
             tracing::warn!(
                 target: LOG_TARGET,
                 ?error,
-                "failed to parse message blocks of `SessionConfirmed`",
+                "failed to parse message blocks of SessionConfirmed",
             );
             debug_assert!(false);
             Ssu2Error::Malformed
@@ -549,7 +549,7 @@ impl<R: Runtime> InboundSsu2Session<R> {
         else {
             tracing::warn!(
                 target: LOG_TARGET,
-                "`SessionConfirmed` doesn't include router info block",
+                "SessionConfirmed doesn't include router info block",
             );
             debug_assert!(false);
             return Err(Ssu2Error::Malformed);
@@ -612,6 +612,7 @@ impl<R: Runtime> InboundSsu2Session<R> {
             pkt,
             started: self.started,
             target: self.address,
+            k_header_2,
         }))
     }
 
@@ -639,7 +640,9 @@ impl<R: Runtime> InboundSsu2Session<R> {
                     "inbound session state is poisoned",
                 );
                 debug_assert!(false);
+
                 Ok(Some(PendingSsu2SessionStatus::SessionTerminated {
+                    address: None,
                     connection_id: self.dst_id,
                     started: self.started,
                     router_id: None,
@@ -682,6 +685,7 @@ impl<R: Runtime> Future for InboundSsu2Session<R> {
                     );
 
                     return Poll::Ready(PendingSsu2SessionStatus::SessionTerminated {
+                        address: None,
                         connection_id: self.dst_id,
                         router_id: None,
                         started: self.started,

--- a/emissary-core/src/transport/ssu2/session/pending/mod.rs
+++ b/emissary-core/src/transport/ssu2/session/pending/mod.rs
@@ -59,6 +59,12 @@ pub enum PendingSsu2SessionStatus<R: Runtime> {
 
         /// Socket address of the remote router.
         target: SocketAddr,
+
+        /// Key for decrypting the header of a `SessionConfirmed` message
+        ///
+        /// Only used by inbound connections which have been rejected by
+        /// `TransportManager` and are now trying to terminate the connection.
+        k_header_2: [u8; 32],
     },
 
     /// New outbound session.
@@ -75,6 +81,9 @@ pub enum PendingSsu2SessionStatus<R: Runtime> {
 
     /// Pending session terminated due to fatal error, e.g., decryption error.
     SessionTerminated {
+        /// Address of remote peer.
+        address: Option<SocketAddr>,
+
         /// Connection ID.
         ///
         /// Either destination or source connection ID, depending on whether the session
@@ -136,12 +145,14 @@ impl<R: Runtime> fmt::Debug for PendingSsu2SessionStatus<R> {
                 .field("started", &started)
                 .finish_non_exhaustive(),
             PendingSsu2SessionStatus::SessionTerminated {
+                address,
                 connection_id,
                 router_id,
                 started,
                 ..
             } => f
                 .debug_struct("PendingSsu2SessionStatus::SessionTerminated")
+                .field("address", &address)
                 .field("connection_id", &connection_id)
                 .field("router_id", &router_id)
                 .field("started", &started)


### PR DESCRIPTION
Previously if two routers dialed each other at the same time, i.e., they had both pending inbound and outbound connections active at the same time for the same router, the inbound connection would get negotiated but since an outbound connection was pending, `TransportManager` would reject the inbound connection.

The outbound connection was then left in a state where it was waiting for the first ack to be received which was never sent because the inbound connection in the other router was rejected

Furthermore, failed outbound connections were treated as failed inbound connections (remote router ID missing) and hence the dial failure was never reported to `TransportManger` which left the router in an unrecoverable state. Subsystems would get notified that the dial failed and would attempt to dial the router again at a later time but since `TransportManager` assumed the router was being dialed, it prevented any further dials.

If `TransportManager` rejects an inbound connection, convert the pending connection into a terminating connection and keep sending termination message to remote router in response to any received message, either `Data` or `SessionConfirmed`.

This allows the remote participant to immediately notice if the connection was rejected by `TransportManager` and try again later

Resolves #245 