### PR TITLE
streaming: Resend reply SYN if it doesn't get acknowledged

### DIFF
--- a/emissary-core/src/sam/protocol/streaming/mod.rs
+++ b/emissary-core/src/sam/protocol/streaming/mod.rs
@@ -3021,7 +3021,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stream_exists_after_multiple_lease_set_query_failures() {
+    async fn stream_exits_after_multiple_lease_set_query_failures() {
         let socket_factory = SocketFactory::new().await;
 
         let mut manager1 = {
@@ -3140,15 +3140,6 @@ mod tests {
                 let _ = manager2.next().await;
             }
         });
-
-        match tokio::time::timeout(Duration::from_secs(50), manager1.next())
-            .await
-            .expect("no timeout")
-            .expect("to succeed")
-        {
-            StreamManagerEvent::SendPacket { .. } => {}
-            _ => panic!("invalid event"),
-        }
 
         match tokio::time::timeout(Duration::from_secs(50), manager1.next())
             .await

--- a/emissary-core/tests/sam.rs
+++ b/emissary-core/tests/sam.rs
@@ -783,7 +783,7 @@ async fn stream_lots_of_data(kind: TransportKind) {
 
         stream.write_all(&data).await.unwrap();
 
-        tokio::time::sleep(Duration::from_secs(10)).await;
+        tokio::time::sleep(Duration::from_secs(30)).await;
     });
 
     let mut session2 = tokio::time::timeout(


### PR DESCRIPTION
Previously `Stream` would send a reply SYN and just assumed it would be received by the remote participant without keeping track of it

This resulted in flakiness as the inbound stream would start sending actual client data after the SYN packet but if the SYN was never received by the outbound participant, it would reject all client data packets which sometimes resulted in streams timing out in tests

When `Stream` is initialized as a new inbound stream, send the SYN reply and keep track of it in unACKed packets so it can be resent if no response is received