### PR TITLE
sam: Add support for `QUIT`/`EXIT`/`STOP`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7238,9 +7238,9 @@ dependencies = [
 
 [[package]]
 name = "yosemite"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86c748ec2dc7c046509d5a70fd5ca1978510ee6d425dd23c1b597806d83deb6"
+checksum = "9ab20c332a3bb36fde777a7be3c11c08ed08a65fe51b41a6c8b202873408b6bc"
 dependencies = [
  "futures",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ toml = "0.8.23"
 tracing-subscriber = { version = "0.3.19", features = ["chrono", "env-filter", "time"] }
 tracing = { version = "0.1.41", default-features = false }
 x25519-dalek = { version = "2.0.1", default-features = false }
-yosemite = { version = "0.6.2", features = ["async-extra"] }
+yosemite = { version = "0.6.3", features = ["async-extra"] }
 
 [profile.testnet]
 inherits = "release"

--- a/emissary-core/src/sam/session.rs
+++ b/emissary-core/src/sam/session.rs
@@ -1401,6 +1401,14 @@ impl<R: Runtime> Future for SamSession<R> {
                         }
                     }
                 }
+                SamCommand::Quit => {
+                    tracing::info!(
+                        target: LOG_TARGET,
+                        session_id = %self.session_id,
+                        "shutting down session",
+                    );
+                    return Poll::Ready(Arc::clone(&self.session_id));
+                }
                 command => tracing::warn!(
                     target: LOG_TARGET,
                     %command,


### PR DESCRIPTION
If one of these commands is sent to an active session through the session's own control socket, the session quits immediately, skipping graceful shutdown

Resolves #263 