### PR TITLE
core: address warning about private macro usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3586,11 +3586,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
- "byteorder",
  "lazy_static",
  "libm",
  "num-integer",
@@ -4784,9 +4783,9 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rsa"
-version = "0.9.8"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
  "const-oid",
  "digest",

--- a/emissary-core/fuzz/Cargo.lock
+++ b/emissary-core/fuzz/Cargo.lock
@@ -1423,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c79c15c05d4bf82b6f5ef163104cc81a760d8e874d38ac50ab67c8877b647b"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
  "lazy_static",
  "libm",
@@ -1846,9 +1846,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.8"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
  "const-oid",
  "digest",

--- a/emissary-util/Cargo.toml
+++ b/emissary-util/Cargo.toml
@@ -20,7 +20,7 @@ metrics = { version = "0.24.2", optional = true }
 natpmp = "0.5.0"
 netdev = { version = "0.36.0", default-features = false, features = ["gateway"] }
 pem = { version = "3.0.5", default-features = false }
-rsa = { version = "0.9.8", features = ["sha2"] }
+rsa = { version = "0.9.10", features = ["sha2"] }
 x509-parser = "0.17.0"
 zip = { version = "4.2.0", default-features = false, features = ["deflate-flate2-zlib"] }
 


### PR DESCRIPTION
The warning:

    warning: the following packages contain code that will be rejected by a future version of Rust: num-bigint-dig v0.8.5

See also:

* https://github.com/rust-lang/rust/issues/120192
* https://github.com/altonen/emissary/actions/runs/21560316462/job/62123264159#step:5:490