### PR TITLE
ssu2: Refactor `TransmissionManager`

### DIFF
--- a/emissary-core/src/transport/ssu2/duplicate.rs
+++ b/emissary-core/src/transport/ssu2/duplicate.rs
@@ -29,7 +29,7 @@ use core::{
 };
 
 /// Logging target for the file.
-const LOG_TARGET: &str = "emissary::ssu2::active::duplicate-filter";
+const LOG_TARGET: &str = "emissary::ssu2::duplicate-filter";
 
 /// Duplicate filter decay interval.
 const DUPLICATE_FILTER_DECAY_INTERVAL: Duration = Duration::from_secs(60);

--- a/emissary-core/src/transport/ssu2/message/mod.rs
+++ b/emissary-core/src/transport/ssu2/message/mod.rs
@@ -260,6 +260,22 @@ pub enum PeerTestMessage {
     Dummy,
 }
 
+impl PeerTestMessage {
+    /// Get nonce of the message
+    ///
+    /// Returns `None` if the message doesn't contain a nonce. This can only happen
+    /// if a faulty/malicious router sends an in-session message 5, 6, or 7.
+    pub fn nonce(&self) -> Option<u32> {
+        match self {
+            Self::Message1 { nonce, .. } => Some(*nonce),
+            Self::Message2 { nonce, .. } => Some(*nonce),
+            Self::Message3 { nonce, .. } => Some(*nonce),
+            Self::Message4 { nonce, .. } => Some(*nonce),
+            _ => None,
+        }
+    }
+}
+
 /// SSU2 message block.
 pub enum Block {
     /// Date time.

--- a/emissary-core/src/transport/ssu2/mod.rs
+++ b/emissary-core/src/transport/ssu2/mod.rs
@@ -37,6 +37,7 @@ use core::{
 };
 use thingbuf::mpsc::Sender;
 
+mod duplicate;
 mod message;
 mod metrics;
 mod peer_test;

--- a/emissary-core/src/transport/ssu2/peer_test/mod.rs
+++ b/emissary-core/src/transport/ssu2/peer_test/mod.rs
@@ -261,7 +261,7 @@ impl<R: Runtime> PeerTestManager<R> {
     }
 
     /// Get handle to `PeerTestManager`.
-    pub fn handle(&self) -> PeerTestHandle {
+    pub fn handle(&self) -> PeerTestHandle<R> {
         PeerTestHandle::new(self.tx.clone())
     }
 

--- a/emissary-core/src/transport/ssu2/session/active/ack.rs
+++ b/emissary-core/src/transport/ssu2/session/active/ack.rs
@@ -136,23 +136,6 @@ impl RemoteAckManager {
         }
     }
 
-    /// Register non-ACK-eliciting packet.
-    pub fn register_non_ack_eliciting_pkt(&mut self, pkt_num: u32) {
-        self.register_pkt(pkt_num);
-    }
-
-    /// Register ACK.
-    ///
-    /// - `ack_through` marks the highest packet that was ACKed.
-    /// - `num_acks` marks the number of ACKs below `ack_through`
-    /// - `range` contains a `(# of NACK, # of ACK)` tuples
-    ///
-    /// [`RemoteAckManager`] checks if any of the received ACKs are related to sent ACK packets,
-    /// allowing it to stop tracking those packets.
-    pub fn register_ack(&mut self, _ack_through: u32, _num_acks: u8, _ranges: &[(u8, u8)]) {
-        // TODO: print something if this acked our ack
-    }
-
     /// Get ACK information added to an outbound message.
     pub fn ack_info(&mut self) -> AckInfo {
         // the first packet in `packets` is always `Packet::Received`

--- a/emissary-core/src/transport/ssu2/session/mod.rs
+++ b/emissary-core/src/transport/ssu2/session/mod.rs
@@ -21,6 +21,7 @@ pub mod pending;
 pub mod terminating;
 
 /// Key context for an active session.
+#[derive(Clone)]
 pub struct KeyContext {
     /// Key for encrypting/decrypting `Data` payloads.
     pub k_data: [u8; 32],

--- a/emissary-core/src/transport/ssu2/socket.rs
+++ b/emissary-core/src/transport/ssu2/socket.rs
@@ -294,7 +294,10 @@ impl<R: Runtime> Ssu2Socket<R> {
 
                     return Err(Ssu2Error::Channel(ChannelError::Closed));
                 }
-                Err(_) => return Err(Ssu2Error::Channel(ChannelError::Full)),
+                Err(_) => {
+                    self.router_ctx.metrics_handle().counter(NUM_DROPS_CHANNEL_FULL).increment(1);
+                    return Err(Ssu2Error::Channel(ChannelError::Full));
+                }
             }
         }
 


### PR DESCRIPTION
Refactor `TransmissionManager` to handle packetization and simplify the logic in `Ssu2Session` to only call `TransmissionManager::drain()` and `TransmissionManager::drain_expired()`

Replace `TransmissionManager::segment()` with `TransmissionManager::schedule()` which accepts both I2NP and peer test messages and doesn't automatically return the (fragmented) segments but buffers them into `TransmissionManager` and packetizes them only when `TransmissionManager::drain()` is called

Add `DuplicateFilter` for `PeerTestHandle` in order to gracefully handle duplicate messages received due to retransmissions.

Related to #51 