### PR TITLE
TransitTunnelManager does not remove transit tunnels early enough

### DIFF
--- a/emissary-core/src/tunnel/transit/inbound.rs
+++ b/emissary-core/src/tunnel/transit/inbound.rs
@@ -227,6 +227,7 @@ impl<R: Runtime> Future for InboundGateway<R> {
                         tunnel_id = %self.tunnel_id,
                         "message channel closed",
                     );
+                    self.subsystem_handle.remove_tunnel(&self.tunnel_id);
                     self.metrics_handle.gauge(NUM_IBGWS).decrement(1);
                     return Poll::Ready(self.tunnel_id);
                 }
@@ -313,6 +314,7 @@ impl<R: Runtime> Future for InboundGateway<R> {
                         tunnel_id = %self.tunnel_id,
                         "shutting down tunnel after 2 minutes of inactivity",
                     );
+                    self.subsystem_handle.remove_tunnel(&self.tunnel_id);
                     self.metrics_handle.gauge(NUM_IBGWS).decrement(1);
                     self.metrics_handle.gauge(NUM_TRANSIT_TUNNELS).decrement(1);
                     self.metrics_handle.counter(NUM_TERMINATED).increment(1);
@@ -330,6 +332,7 @@ impl<R: Runtime> Future for InboundGateway<R> {
         }
 
         if self.expiration_timer.poll_unpin(cx).is_ready() {
+            self.subsystem_handle.remove_tunnel(&self.tunnel_id);
             self.metrics_handle.gauge(NUM_IBGWS).decrement(1);
             self.metrics_handle.gauge(NUM_TRANSIT_TUNNELS).decrement(1);
 

--- a/emissary-core/src/tunnel/transit/mod.rs
+++ b/emissary-core/src/tunnel/transit/mod.rs
@@ -870,15 +870,13 @@ impl<R: Runtime> Future for TransitTunnelManager<R> {
                 return Poll::Ready(());
             };
 
-            let tunnel_id = match result {
+            match result {
                 Ok(tunnel_id) => {
                     tracing::debug!(
                         target: LOG_TARGET,
                         %tunnel_id,
                         "transit tunnel expired",
                     );
-
-                    tunnel_id
                 }
                 Err(tunnel_id) => {
                     tracing::debug!(
@@ -886,12 +884,8 @@ impl<R: Runtime> Future for TransitTunnelManager<R> {
                         %tunnel_id,
                         "failed to dial next hop, unable to start transit tunnel",
                     );
-
-                    tunnel_id
                 }
-            };
-
-            self.subsystem_handle.remove_tunnel(&tunnel_id);
+            }
 
             if self.tunnels.is_empty() && self.shutdown_handle.is_shutting_down() {
                 tracing::info!(

--- a/emissary-core/src/tunnel/transit/outbound.rs
+++ b/emissary-core/src/tunnel/transit/outbound.rs
@@ -354,6 +354,7 @@ impl<R: Runtime> Future for OutboundEndpoint<R> {
                         tunnel_id = %self.tunnel_id,
                         "message channel closed",
                     );
+                    self.subsystem_handle.remove_tunnel(&self.tunnel_id);
                     self.metrics_handle.gauge(NUM_OBEPS).decrement(1);
                     return Poll::Ready(self.tunnel_id);
                 }
@@ -426,6 +427,7 @@ impl<R: Runtime> Future for OutboundEndpoint<R> {
                         tunnel_id = %self.tunnel_id,
                         "shutting down tunnel after 2 minutes of inactivity",
                     );
+                    self.subsystem_handle.remove_tunnel(&self.tunnel_id);
                     self.metrics_handle.gauge(NUM_OBEPS).decrement(1);
                     self.metrics_handle.gauge(NUM_TRANSIT_TUNNELS).decrement(1);
                     self.metrics_handle.counter(NUM_TERMINATED).increment(1);
@@ -443,6 +445,7 @@ impl<R: Runtime> Future for OutboundEndpoint<R> {
         }
 
         if self.expiration_timer.poll_unpin(cx).is_ready() {
+            self.subsystem_handle.remove_tunnel(&self.tunnel_id);
             self.metrics_handle.gauge(NUM_OBEPS).decrement(1);
             self.metrics_handle.gauge(NUM_TRANSIT_TUNNELS).decrement(1);
 

--- a/emissary-core/src/tunnel/transit/participant.rs
+++ b/emissary-core/src/tunnel/transit/participant.rs
@@ -173,6 +173,7 @@ impl<R: Runtime> Future for Participant<R> {
                         tunnel_id = %self.tunnel_id,
                         "message channel closed",
                     );
+                    self.subsystem_handle.remove_tunnel(&self.tunnel_id);
                     self.metrics_handle.gauge(NUM_PARTICIPANTS).decrement(1);
                     return Poll::Ready(self.tunnel_id);
                 }
@@ -246,6 +247,7 @@ impl<R: Runtime> Future for Participant<R> {
                         tunnel_id = %self.tunnel_id,
                         "shutting down tunnel after 2 minutes of inactivity",
                     );
+                    self.subsystem_handle.remove_tunnel(&self.tunnel_id);
                     self.metrics_handle.gauge(NUM_PARTICIPANTS).decrement(1);
                     self.metrics_handle.gauge(NUM_TRANSIT_TUNNELS).decrement(1);
                     self.metrics_handle.counter(NUM_TERMINATED).increment(1);
@@ -263,6 +265,7 @@ impl<R: Runtime> Future for Participant<R> {
         }
 
         if self.expiration_timer.poll_unpin(cx).is_ready() {
+            self.subsystem_handle.remove_tunnel(&self.tunnel_id);
             self.metrics_handle.gauge(NUM_PARTICIPANTS).decrement(1);
             self.metrics_handle.gauge(NUM_TRANSIT_TUNNELS).decrement(1);
 


### PR DESCRIPTION
Closes #248.

Admittedly, I'm not sure if this is what you had in mind, @altonen.