### PR TITLE
cli: unclear which tunnel exited

### DIFF
--- a/emissary-cli/src/tunnel/client.rs
+++ b/emissary-cli/src/tunnel/client.rs
@@ -144,7 +144,11 @@ impl ClientTunnelManager {
                     debug_assert!(false);
                 }
                 Ok(tunnel) => {
-                    tracing::error!(target: LOG_TARGET, "tunnel returned, restart event loop");
+                    tracing::info!(
+                        target: LOG_TARGET,
+                        name = %tunnel.name,
+                        "tunnel returned, restart event loop"
+                    );
 
                     let future = session.connect_detached_with_options(
                         &tunnel.destination,


### PR DESCRIPTION
Added slightly more context to the logs, because it wasn't clear which tunnel was not functioning properly.