### PR TITLE
cli: Implement `RouterCommand::RouterUiDev`

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -37,6 +37,7 @@ export default defineConfig({
         text: "Development",
         items: [
           { text: "Debugging", link: "/debugging.md" },
+          { text: "Development", link: "/development.md" },
         ]
       },
     ],

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,17 @@
+---
+outline: deep
+---
+
+# Developing `emissary`
+
+## Modifying router UIs
+
+The router can be started in "router UI only" mode which starts the UI (native or web) without connecting to the network:
+
+```bash
+# native ui
+cargo run -- router-ui-dev
+
+# web ui
+cargo run --no-default-features --features web-ui -- router-ui-dev
+```

--- a/emissary-cli/src/cli.rs
+++ b/emissary-cli/src/cli.rs
@@ -20,7 +20,7 @@ use clap::{Args, Parser};
 
 use crate::{config::Theme, tools::RouterCommand};
 
-#[derive(Args)]
+#[derive(Args, Default)]
 pub struct TunnelOptions {
     /// Length of an inbound exploratory tunnel
     #[arg(long, value_name = "NUM")]
@@ -47,7 +47,7 @@ pub struct TunnelOptions {
     pub insecure_tunnels: Option<bool>,
 }
 
-#[derive(Args)]
+#[derive(Args, Default)]
 pub struct TransitOptions {
     /// Maximum number of transit tunnels.
     #[arg(long, value_name = "MAX_TUNNELS")]
@@ -58,7 +58,7 @@ pub struct TransitOptions {
     pub disable_transit_tunnels: Option<bool>,
 }
 
-#[derive(Args)]
+#[derive(Args, Default)]
 pub struct ReseedOptions {
     /// Comma-separated list of reseed hosts
     ///
@@ -84,7 +84,7 @@ pub struct ReseedOptions {
     pub disable_force_ipv4: Option<bool>,
 }
 
-#[derive(Args)]
+#[derive(Args, Default)]
 pub struct MetricsOptions {
     /// Metrics server port.
     #[arg(long)]
@@ -95,7 +95,7 @@ pub struct MetricsOptions {
     pub disable_metrics: Option<bool>,
 }
 
-#[derive(Args)]
+#[derive(Args, Default)]
 pub struct HttpProxyOptions {
     /// HTTP proxy port.
     ///
@@ -114,7 +114,7 @@ pub struct HttpProxyOptions {
     pub http_outproxy: Option<String>,
 }
 
-#[derive(Args)]
+#[derive(Args, Default)]
 pub struct SocksProxyOptions {
     /// SOCKS proxy port.
     ///
@@ -129,7 +129,7 @@ pub struct SocksProxyOptions {
     pub socks_proxy_host: Option<String>,
 }
 
-#[derive(Args)]
+#[derive(Args, Default)]
 pub struct PortForwardingOptions {
     /// Disable UPnP.
     #[arg(long, action = clap::ArgAction::SetTrue)]
@@ -144,7 +144,7 @@ pub struct PortForwardingOptions {
     pub upnp_name: Option<String>,
 }
 
-#[derive(Args)]
+#[derive(Args, Default)]
 pub struct RouterUiOptions {
     /// Disable router UI
     #[arg(long, action = clap::ArgAction::SetTrue)]
@@ -169,7 +169,7 @@ pub struct RouterUiOptions {
     pub web_ui_port: Option<u16>,
 }
 
-#[derive(Parser)]
+#[derive(Parser, Default)]
 #[command(version, about)]
 pub struct Arguments {
     /// Base path where all i2p-related files are stored

--- a/emissary-cli/src/tools/mod.rs
+++ b/emissary-cli/src/tools/mod.rs
@@ -21,12 +21,12 @@ use clap::{ArgGroup, Subcommand};
 mod base64;
 mod devnet;
 
+#[cfg(any(feature = "native-ui", feature = "web-ui"))]
+mod router_ui_dev;
+
 /// Logging target for the file.
 const LOG_TARGET: &str = "emissary::tools";
 
-/// Router commands.
-///
-/// These are inspired by [`i2pd-tools`](https://github.com/PurpleI2P/i2pd-tools/).
 #[derive(Subcommand)]
 pub enum RouterCommand {
     /// Base64-encode data using the I2P Base64 alphabet.
@@ -95,6 +95,12 @@ pub enum RouterCommand {
         #[arg(short = 'p', long, value_name = "PATH")]
         path: Option<String>,
     },
+
+    /// Start the router UI (either native or web) in development mode.
+    ///
+    /// The actual router is not started and the router UI is fed mock data.
+    #[cfg(any(feature = "native-ui", feature = "web-ui"))]
+    RouterUiDev,
 }
 
 impl RouterCommand {
@@ -132,6 +138,8 @@ impl RouterCommand {
                 num_routers,
                 path,
             } => devnet::spawn_network(num_floodfills, num_routers, path).await,
+            #[cfg(any(feature = "native-ui", feature = "web-ui"))]
+            RouterCommand::RouterUiDev => router_ui_dev::run().await,
         }
 
         std::process::exit(0);

--- a/emissary-cli/src/tools/router_ui_dev.rs
+++ b/emissary-cli/src/tools/router_ui_dev.rs
@@ -1,0 +1,155 @@
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#![cfg(any(feature = "native-ui", feature = "web-ui"))]
+
+use crate::ui;
+
+use emissary_core::{
+    events::{EventHandle, EventManager, TransitTunnelStatus, TransportStatus, TunnelStatus},
+    runtime::Runtime,
+};
+use emissary_util::runtime::tokio::Runtime as TokioRuntime;
+use rand::Rng;
+
+use std::time::Duration;
+
+struct RouterState {
+    transit: TransitTunnelStatus,
+    transport: TransportStatus,
+    tunnel: TunnelStatus,
+    handle: EventHandle<TokioRuntime>,
+}
+
+impl RouterState {
+    fn new(handle: EventHandle<TokioRuntime>) -> Self {
+        Self {
+            handle,
+            transit: TransitTunnelStatus {
+                num_tunnels: 50,
+                inbound_bandwidth: 10_000,
+                outbound_bandwidth: 8_000,
+            },
+            transport: TransportStatus {
+                num_connected_routers: 100,
+                inbound_bandwidth: 15_000,
+                outbound_bandwidth: 12_000,
+            },
+            tunnel: TunnelStatus {
+                num_tunnels_built: 200,
+                num_tunnel_build_failures: 5,
+            },
+        }
+    }
+
+    async fn run(mut self) {
+        loop {
+            {
+                let mut rng = rand::thread_rng();
+
+                let mut delta = |value: usize, max_change: i32| -> usize {
+                    let change: i32 = rng.gen_range(-max_change..=max_change);
+                    let new = value as i32 + change;
+                    new.max(0) as usize
+                };
+
+                // transit updates
+                {
+                    self.transit.num_tunnels = delta(self.transit.num_tunnels, 3);
+                    self.handle.num_transit_tunnels(self.transit.num_tunnels);
+
+                    self.transit.inbound_bandwidth = delta(self.transit.inbound_bandwidth, 500);
+                    self.handle.transit_inbound_bandwidth(self.transit.inbound_bandwidth);
+
+                    self.transit.outbound_bandwidth = delta(self.transit.outbound_bandwidth, 500);
+                    self.handle.transit_outbound_bandwidth(self.transit.outbound_bandwidth);
+                }
+
+                // transport updates
+                {
+                    self.transport.num_connected_routers =
+                        delta(self.transport.num_connected_routers, 5);
+                    self.handle.num_connected_routers(self.transport.num_connected_routers);
+
+                    self.transport.inbound_bandwidth =
+                        delta(self.transport.inbound_bandwidth, 1000);
+                    self.handle.transport_inbound_bandwidth(self.transport.inbound_bandwidth);
+
+                    self.transport.outbound_bandwidth =
+                        delta(self.transport.outbound_bandwidth, 1000);
+                    self.handle.transport_outbound_bandwidth(self.transport.outbound_bandwidth);
+                }
+
+                // tunnel updates
+                {
+                    self.tunnel.num_tunnels_built = delta(self.tunnel.num_tunnels_built, 2);
+                    self.tunnel.num_tunnel_build_failures =
+                        delta(self.tunnel.num_tunnel_build_failures, 1);
+
+                    self.handle.tunnel_status(
+                        self.tunnel.num_tunnels_built,
+                        self.tunnel.num_tunnel_build_failures,
+                    );
+                }
+            }
+
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    }
+}
+
+/// Start the router UI (either native or web) in development mode.
+///
+/// The actual router is not started and the router UI is fed mock data.
+pub async fn run() {
+    let (shutdown_tx, _shutdown_rx) = tokio::sync::mpsc::channel(1);
+    let metrics_handle = TokioRuntime::register_metrics(vec![], None);
+    let (manager, subscriber, handle) = EventManager::<TokioRuntime>::new(None, metrics_handle);
+
+    tokio::spawn(manager);
+    tokio::spawn(RouterState::new(handle).run());
+
+    #[cfg(feature = "native-ui")]
+    {
+        use crate::{cli::Arguments, config::Config};
+        use emissary_core::primitives::RouterId;
+        use emissary_util::storage::Storage;
+        use tempfile::tempdir;
+
+        let dir = tempdir().expect("to succeed");
+        let base_path = dir.path().to_owned();
+        let storage = Storage::new(Some(base_path.clone())).await.unwrap();
+        let mut config = Config::parse(&Arguments::default(), &storage).await.unwrap();
+
+        println!("confguration path = {}", base_path.display());
+
+        let _ = ui::native::RouterUi::start(
+            subscriber,
+            config.config.take().unwrap(),
+            base_path,
+            None,
+            RouterId::from(rand::thread_rng().gen::<[u8; 32]>()),
+            shutdown_tx,
+        );
+    }
+
+    #[cfg(feature = "web-ui")]
+    {
+        ui::web::RouterUi::new(subscriber, None, 1, shutdown_tx).run().await;
+    }
+}

--- a/emissary-core/src/events.rs
+++ b/emissary-core/src/events.rs
@@ -86,7 +86,7 @@ impl Default for SubsystemEvent {
 
 /// Event handle.
 #[cfg(feature = "events")]
-pub(crate) struct EventHandle<R: Runtime> {
+pub struct EventHandle<R: Runtime> {
     /// TX channel for sending events to [`EventSubscriber`].
     event_tx: Sender<SubsystemEvent>,
 
@@ -154,7 +154,7 @@ impl<R: Runtime> EventHandle<R> {
     /// [`AtomicUsize::store()`] is used because the count is updated only by
     /// `TransitTunnelManager`.
     #[inline(always)]
-    pub(crate) fn num_transit_tunnels(&self, _num_tunnels: usize) {
+    pub fn num_transit_tunnels(&self, _num_tunnels: usize) {
         #[cfg(feature = "events")]
         self.num_transit_tunnels.store(_num_tunnels, Ordering::Release);
     }
@@ -163,7 +163,7 @@ impl<R: Runtime> EventHandle<R> {
     ///
     /// [`AtomicUsize::fetch_add()`] is used because each transit tunnel keeps track
     /// of its own bandwidth.
-    pub(crate) fn transit_inbound_bandwidth(&self, _bandwidth: usize) {
+    pub fn transit_inbound_bandwidth(&self, _bandwidth: usize) {
         #[cfg(feature = "events")]
         self.transit_inbound_bandwidth.fetch_add(_bandwidth, Ordering::Release);
     }
@@ -173,7 +173,7 @@ impl<R: Runtime> EventHandle<R> {
     /// [`AtomicUsize::fetch_add()`] is used because each transit tunnel keeps track
     /// of its own bandwidth.
     #[inline(always)]
-    pub(crate) fn transit_outbound_bandwidth(&self, _bandwidth: usize) {
+    pub fn transit_outbound_bandwidth(&self, _bandwidth: usize) {
         #[cfg(feature = "events")]
         self.transit_outbound_bandwidth.fetch_add(_bandwidth, Ordering::Release);
     }
@@ -183,7 +183,7 @@ impl<R: Runtime> EventHandle<R> {
     /// [`AtomicUsize::fetch_add()`] is used because each connection keeps track of its own
     /// bandwidth.
     #[inline(always)]
-    pub(crate) fn transport_inbound_bandwidth(&self, _bandwidth: usize) {
+    pub fn transport_inbound_bandwidth(&self, _bandwidth: usize) {
         #[cfg(feature = "events")]
         self.inbound_bandwidth.fetch_add(_bandwidth, Ordering::Release);
     }
@@ -193,7 +193,7 @@ impl<R: Runtime> EventHandle<R> {
     /// [`AtomicUsize::fetch_add()`] is used because each connection keeps track of its own
     /// bandwidth.
     #[inline(always)]
-    pub(crate) fn transport_outbound_bandwidth(&self, _bandwidth: usize) {
+    pub fn transport_outbound_bandwidth(&self, _bandwidth: usize) {
         #[cfg(feature = "events")]
         self.outbound_bandwidth.fetch_add(_bandwidth, Ordering::Release);
     }
@@ -203,7 +203,7 @@ impl<R: Runtime> EventHandle<R> {
     /// [`AtomicUsize::store()`] is used because the count is updated only by
     /// `TransportManager`.
     #[inline(always)]
-    pub(crate) fn num_connected_routers(&self, _num_connected_routers: usize) {
+    pub fn num_connected_routers(&self, _num_connected_routers: usize) {
         #[cfg(feature = "events")]
         self.num_connected_routers.store(_num_connected_routers, Ordering::Release);
     }
@@ -213,11 +213,7 @@ impl<R: Runtime> EventHandle<R> {
     /// [`AtomicUsize::fetch_add()`] is used because each tunnel pool keeps track of its own
     /// tunnel build success/failure rate.
     #[inline(always)]
-    pub(crate) fn tunnel_status(
-        &self,
-        _num_tunnels_built: usize,
-        _num_tunnel_build_failures: usize,
-    ) {
+    pub fn tunnel_status(&self, _num_tunnels_built: usize, _num_tunnel_build_failures: usize) {
         #[cfg(feature = "events")]
         self.num_tunnels_built.fetch_add(_num_tunnels_built, Ordering::Release);
         #[cfg(feature = "events")]
@@ -227,7 +223,7 @@ impl<R: Runtime> EventHandle<R> {
 
     /// Notify the [`EventManager`] that a server destination was started.
     #[inline(always)]
-    pub(crate) fn server_destination_started(&self, _name: String, _address: String) {
+    pub fn server_destination_started(&self, _name: String, _address: String) {
         #[cfg(feature = "events")]
         let _ = self.event_tx.try_send(SubsystemEvent::ServerDestinationStarted {
             name: _name,
@@ -237,14 +233,14 @@ impl<R: Runtime> EventHandle<R> {
 
     /// Notify the [`EventManager`] that a client destination was started.
     #[inline(always)]
-    pub(crate) fn client_destination_started(&self, _name: String) {
+    pub fn client_destination_started(&self, _name: String) {
         #[cfg(feature = "events")]
         let _ = self.event_tx.try_send(SubsystemEvent::ClientDestinationStarted { name: _name });
     }
 
     /// Create new `EventHandle` for tests.
     #[cfg(test)]
-    pub(crate) fn new_for_tests() -> Self {
+    pub fn new_for_tests() -> Self {
         let (event_tx, _event_rx) = channel(16);
 
         Self {
@@ -385,7 +381,7 @@ enum State {
 
 /// Event manager.
 #[cfg(feature = "events")]
-pub(crate) struct EventManager<R: Runtime> {
+pub struct EventManager<R: Runtime> {
     /// RX channel for receiving events from other subsystems.
     event_rx: Receiver<SubsystemEvent>,
 
@@ -432,7 +428,7 @@ pub(crate) struct EventManager<R: Runtime> {
 impl<R: Runtime> EventManager<R> {
     /// Create new [`EventManager`].
     #[cfg(feature = "events")]
-    pub(crate) fn new(
+    pub fn new(
         update_interval: Option<Duration>,
         metrics_handle: R::MetricsHandle,
     ) -> (Self, EventSubscriber, EventHandle<R>) {


### PR DESCRIPTION
The command allows starting the router UI (either native or web) in development mode where the actual router is not started and the UI is fed mock data