### PR TITLE
cli/socks: Implement outproxy support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,13 +1703,14 @@ dependencies = [
 
 [[package]]
 name = "fast-socks5"
-version = "0.10.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09fe4a491909a716088083eeb5bcc25427330fdbcd4ecd3dfa5469b3da795df"
+checksum = "9545787d8304a71e1bf1b711705070a4c400cce9b332c4a11800627b7c9a2067"
 dependencies = [
  "anyhow",
  "async-trait",
  "log",
+ "socket2 0.5.9",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",

--- a/emissary-cli/Cargo.toml
+++ b/emissary-cli/Cargo.toml
@@ -40,7 +40,7 @@ tracing = { workspace = true, features = ["log"] }
 yosemite = { workspace = true }
 
 [dev-dependencies]
-fast-socks5 = { version = "0.10.0", features = ["socks4"] }
+fast-socks5 = { version = "1.0.0", features = ["socks4"] }
 
 [features]
 default = ["native-ui"]

--- a/emissary-cli/src/cli.rs
+++ b/emissary-cli/src/cli.rs
@@ -127,6 +127,10 @@ pub struct SocksProxyOptions {
     /// Defaults to 127.0.0.1
     #[arg(long, value_name = "HOST")]
     pub socks_proxy_host: Option<String>,
+
+    /// SOCKS outproxy.
+    #[arg(long, value_name = "OUTPROXY")]
+    pub socks_outproxy: Option<String>,
 }
 
 #[derive(Args, Default)]

--- a/emissary-cli/src/config.rs
+++ b/emissary-cli/src/config.rs
@@ -138,6 +138,7 @@ pub struct SocksProxyConfig {
     pub port: u16,
     pub host: String,
     pub i2cp: Option<I2cpOptions>,
+    pub outproxy: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -276,7 +277,12 @@ impl EmissaryConfig {
                 tunnel_config: Some(TunnelConfig::default()),
                 i2cp: None,
             }),
-            socks_proxy: None,
+            socks_proxy: Some(SocksProxyConfig {
+                port: 4447,
+                host: "127.0.0.1".to_string(),
+                i2cp: None,
+                outproxy: None,
+            }),
             i2cp: Some(I2cpConfig {
                 port: 7654,
                 host: None,
@@ -821,6 +827,7 @@ impl Config {
                 SocksProxyOptions {
                     socks_proxy_port,
                     socks_proxy_host,
+                    socks_outproxy,
                 },
             ) => {
                 if let Some(port) = socks_proxy_port {
@@ -830,18 +837,24 @@ impl Config {
                 if let Some(host) = &socks_proxy_host {
                     config.host = host.clone();
                 }
+
+                if let Some(outproxy) = &socks_outproxy {
+                    config.outproxy = Some(outproxy.clone());
+                }
             }
             (
                 None,
                 SocksProxyOptions {
                     socks_proxy_port: Some(port),
                     socks_proxy_host: Some(host),
+                    socks_outproxy,
                 },
             ) => {
                 self.socks_proxy = Some(SocksProxyConfig {
                     port: *port,
                     host: host.clone(),
                     i2cp: None,
+                    outproxy: socks_outproxy.clone(),
                 });
             }
             _ => {}
@@ -989,6 +1002,7 @@ mod tests {
             socks_proxy: SocksProxyOptions {
                 socks_proxy_port: None,
                 socks_proxy_host: None,
+                socks_outproxy: None,
             },
             transit: TransitOptions {
                 max_transit_tunnels: None,

--- a/emissary-cli/src/proxy/socks.rs
+++ b/emissary-cli/src/proxy/socks.rs
@@ -34,6 +34,9 @@ const SOCKSV5_TCP: u8 = 0x01;
 /// SOCKSv5 Domain for TCP CONNECT.
 const SOCKSV5_DOMAIN: u8 = 0x03;
 
+/// SOCKSv5 success.
+const SOCKSV5_SUCCESS: u8 = 0x00;
+
 /// SOCKSv5 proxy.
 pub struct SocksProxy {
     /// Pending `TCP CONNECT` futures.
@@ -41,6 +44,9 @@ pub struct SocksProxy {
 
     /// TCP listener for the server.
     listener: TcpListener,
+
+    /// Outproxy, if specified.
+    outproxy: Option<String>,
 
     /// SAMv3 streaming session for the SOCKS proxy.
     session: Session<style::Stream>,
@@ -61,6 +67,7 @@ impl SocksProxy {
 
         Ok(Self {
             futures: JoinSet::new(),
+            outproxy: config.outproxy,
             listener,
             session,
         })
@@ -114,6 +121,125 @@ impl SocksProxy {
         Ok((stream, target, port))
     }
 
+    /// Handle parsed `TCP CONNECT` for `host:port`.
+    ///
+    /// If `host` is not an .i2p address and an outproxy was enabled, the request is routed there.
+    async fn handle_tcp_connect(&mut self, mut stream: TcpStream, host: String, port: u16) {
+        tracing::trace!(
+            target: LOG_TARGET,
+            %host,
+            %port,
+            "connect to remote destination"
+        );
+
+        // route connection request to sam server
+        if host.ends_with(".i2p") {
+            let future = self.session.connect_detached_with_options(
+                &host,
+                StreamOptions {
+                    dst_port: port,
+                    ..Default::default()
+                },
+            );
+
+            tokio::spawn(async move {
+                match future.await {
+                    Err(error) => {
+                        tracing::debug!(
+                            target: LOG_TARGET,
+                            ?error,
+                            "failed to connect to destination",
+                        );
+                        Err(error)
+                    }
+                    Ok(mut i2p_stream) =>
+                        tokio::io::copy_bidirectional(&mut i2p_stream, &mut stream)
+                            .await
+                            .map_err(From::from),
+                }
+            });
+
+            return;
+        }
+
+        // route non-.i2p host connections to outproxy if enabled
+        let outproxy = match &self.outproxy {
+            Some(outproxy) => {
+                tracing::trace!(
+                    target: LOG_TARGET,
+                    %host,
+                    %port,
+                    %outproxy,
+                    "connecting to outproxy",
+                );
+
+                outproxy.clone()
+            }
+            None => {
+                tracing::warn!(
+                    target: LOG_TARGET,
+                    %host,
+                    %port,
+                    "tried to connect to non-.i2p host but outproxy not enabled",
+                );
+                return;
+            }
+        };
+
+        tokio::spawn(async move {
+            async fn connect(
+                mut stream: TcpStream,
+                host: &str,
+                port: u16,
+                outproxy: String,
+            ) -> anyhow::Result<()> {
+                let mut upstream = TcpStream::connect(outproxy).await?;
+
+                // handshake
+                //
+                // version 5, 1 method, no auth
+                upstream.write_all(&[0x05, 0x01, 0x00]).await?;
+                let mut handshake_res = [0u8; 2];
+                upstream.read_exact(&mut handshake_res).await?;
+
+                if handshake_res[1] != SOCKSV5_SUCCESS {
+                    anyhow::bail!("upstream proxy requires authentication");
+                }
+
+                // send connect request for `host`
+                //
+                // version 5, connect, reserved, domain
+                let mut request = vec![0x05, 0x01, 0x00, 0x03];
+                request.push(host.len() as u8);
+                request.extend_from_slice(host.as_bytes());
+                request.extend_from_slice(&port.to_be_bytes());
+                upstream.write_all(&request).await?;
+
+                let mut response = [0u8; 10];
+                upstream.read_exact(&mut response).await?;
+
+                if response[1] != SOCKSV5_SUCCESS {
+                    anyhow::bail!("upstream failed to connect")
+                }
+
+                tokio::io::copy_bidirectional(&mut stream, &mut upstream)
+                    .await
+                    .map(|_| ())
+                    .map_err(From::from)
+            }
+
+            if let Err(error) = connect(stream, &host, port, outproxy).await {
+                tracing::warn!(
+                    target: LOG_TARGET,
+                    %host,
+                    %port,
+                    ?error,
+                    "outproxy connection failed"
+                )
+            }
+        });
+    }
+
     /// Run event loop of [`SocksProxy`].
     pub async fn run(mut self) -> anyhow::Result<()> {
         loop {
@@ -134,40 +260,7 @@ impl SocksProxy {
                         %error,
                         "failed to parse TCP CONNECT",
                     ),
-                    Some(Ok(Ok((mut stream, host, port)))) => {
-                        tracing::trace!(
-                            target: LOG_TARGET,
-                            %host,
-                            %port,
-                            "connect to remote destination"
-                        );
-
-                        let future = self.session.connect_detached_with_options(
-                            &host,
-                            StreamOptions {
-                                dst_port: port,
-                                ..Default::default()
-                            },
-                        );
-
-                        tokio::spawn(async move {
-                            match future.await {
-                                Err(error) => {
-                                    tracing::debug!(
-                                        target: LOG_TARGET,
-                                        ?error,
-                                        "failed to connect to destination",
-                                    );
-                                    Err(error)
-                                }
-                                Ok(mut i2p_stream) => {
-                                    tokio::io::copy_bidirectional(&mut i2p_stream, &mut stream)
-                                        .await
-                                        .map_err(From::from)
-                                }
-                            }
-                        });
-                    }
+                    Some(Ok(Ok((stream, host, port)))) => self.handle_tcp_connect(stream, host, port).await,
                 }
             }
         }
@@ -179,8 +272,10 @@ mod tests {
     use super::*;
     use fast_socks5::{
         client::{Config, Socks5Stream},
+        server::Socks5ServerProtocol,
         socks4::client::Socks4Stream,
     };
+    use std::time::Duration;
     use tokio::io::{AsyncBufReadExt, BufReader};
 
     /// Fake SAMv3 server.
@@ -255,6 +350,7 @@ mod tests {
                 port: 0,
                 host: "127.0.0.1".to_string(),
                 i2cp: None,
+                outproxy: None,
             },
             sam_port,
         )
@@ -286,6 +382,7 @@ mod tests {
                 port: 0,
                 host: "127.0.0.1".to_string(),
                 i2cp: None,
+                outproxy: None,
             },
             sam_port,
         )
@@ -316,6 +413,7 @@ mod tests {
                 port: 0,
                 host: "127.0.0.1".to_string(),
                 i2cp: None,
+                outproxy: None,
             },
             sam_port,
         )
@@ -351,6 +449,7 @@ mod tests {
                 port: 0,
                 host: "127.0.0.1".to_string(),
                 i2cp: None,
+                outproxy: None,
             },
             sam_port,
         )
@@ -381,6 +480,7 @@ mod tests {
                 port: 0,
                 host: "127.0.0.1".to_string(),
                 i2cp: None,
+                outproxy: None,
             },
             sam_port,
         )
@@ -394,5 +494,64 @@ mod tests {
                 .await
                 .is_err()
         )
+    }
+
+    #[tokio::test]
+    async fn outproxy_works() {
+        let sam_port = {
+            let sam = SamServer::new().await;
+            let port = sam.listener.local_addr().unwrap().port();
+            tokio::spawn(sam.run());
+
+            port
+        };
+
+        // create mock socksv5 server
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+
+        let handle = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (_stream, command, address) = Socks5ServerProtocol::accept_no_auth(stream)
+                .await
+                .unwrap()
+                .read_command()
+                .await
+                .unwrap();
+
+            match command {
+                fast_socks5::Socks5Command::TCPConnect => address.to_string(),
+                _ => panic!("invalid command"),
+            }
+        });
+
+        let proxy = SocksProxy::new(
+            SocksProxyConfig {
+                port: 0,
+                host: "127.0.0.1".to_string(),
+                i2cp: None,
+                outproxy: Some(format!("{}:{}", address.ip().to_string(), address.port())),
+            },
+            sam_port,
+        )
+        .await
+        .unwrap();
+        let address = proxy.listener.local_addr().unwrap();
+        tokio::spawn(proxy.run());
+
+        let _stream = Socks5Stream::connect(
+            address,
+            "http://host.onion".to_string(),
+            1337,
+            Config::default(),
+        )
+        .await
+        .unwrap();
+
+        let destination = tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("no timeout")
+            .expect("to succeed");
+        assert_eq!(destination, "http://host.onion:1337".to_string());
     }
 }

--- a/emissary-cli/src/ui/native/mod.rs
+++ b/emissary-cli/src/ui/native/mod.rs
@@ -885,6 +885,12 @@ impl RouterUi {
 
                 Task::none()
             }
+            Message::SocksOutproxyHostChanged(data) => {
+                self.socks_proxy.set_outproxy(data);
+                self.settings_status = SettingsStatus::Idle(self.active_settings_tab);
+
+                Task::none()
+            }
             Message::SocksEnabled(enabled) => {
                 self.socks_proxy.set_enabled(enabled);
                 self.settings_status = SettingsStatus::Idle(self.active_settings_tab);

--- a/emissary-cli/src/ui/native/settings/proxies.rs
+++ b/emissary-cli/src/ui/native/settings/proxies.rs
@@ -212,6 +212,7 @@ impl From<&Option<crate::config::HttpProxyConfig>> for HttpProxyConfig {
 pub struct SocksProxyConfig {
     port: Option<String>,
     host: Option<String>,
+    outproxy: Option<String>,
     enabled: bool,
 }
 
@@ -222,6 +223,10 @@ impl SocksProxyConfig {
 
     fn host(&self) -> &str {
         self.host.as_ref().map_or("", |host| host.as_str())
+    }
+
+    fn outproxy(&self) -> &str {
+        self.outproxy.as_ref().map_or("", |outproxy| outproxy.as_str())
     }
 
     pub fn enabled(&self) -> bool {
@@ -238,6 +243,10 @@ impl SocksProxyConfig {
 
     pub fn set_enabled(&mut self, enabled: bool) {
         self.enabled = enabled;
+    }
+
+    pub fn set_outproxy(&mut self, outproxy: String) {
+        self.outproxy = Some(outproxy);
     }
 }
 
@@ -265,6 +274,11 @@ impl TryInto<Option<crate::config::SocksProxyConfig>> for SocksProxyConfig {
                 host
             },
             i2cp: None,
+            outproxy: match self.outproxy {
+                None => None,
+                Some(host) if host.is_empty() => None,
+                Some(host) => Some(host.clone()),
+            },
         }))
     }
 }
@@ -275,12 +289,14 @@ impl From<&Option<crate::config::SocksProxyConfig>> for SocksProxyConfig {
             Some(value) => Self {
                 port: Some(value.port.to_string()),
                 host: Some(value.host.clone()),
+                outproxy: value.outproxy.clone(),
                 enabled: true,
             },
             None => Self {
                 port: None,
                 host: None,
                 enabled: false,
+                outproxy: None,
             },
         }
     }
@@ -525,6 +541,29 @@ impl RouterUi {
                     TextInput::new("Host", self.socks_proxy.host())
                         .size(15)
                         .on_input(Message::SocksHostChanged)
+                        .padding(10)
+                        .style(
+                            |_theme: &Theme, _status: _| iced::widget::text_input::Style {
+                                border: Border {
+                                    radius: Radius::from(6.0),
+                                    width: 1.0,
+                                    color: Color::from_rgb8(28, 36, 49),
+                                },
+                                background: iced::Background::Color(iced::Color::from_rgb8(
+                                    0x37, 0x41, 0x51,
+                                )),
+                                icon: Color::WHITE,
+                                placeholder: Color::from_rgb8(0x9b, 0xa2, 0xae),
+                                value: Color::from_rgb8(0xf3, 0xf3, 0xf2),
+                                selection: Color::from_rgb8(0x9b, 0xa2, 0xae),
+                            },
+                        ),
+                )
+                .push(Text::new("Outproxy").size(15).color(Color::from_rgb8(0x9b, 0xa2, 0xae)))
+                .push(
+                    TextInput::new("Outproxy", self.socks_proxy.outproxy())
+                        .size(15)
+                        .on_input(Message::SocksOutproxyHostChanged)
                         .padding(10)
                         .style(
                             |_theme: &Theme, _status: _| iced::widget::text_input::Style {

--- a/emissary-cli/src/ui/native/types.rs
+++ b/emissary-cli/src/ui/native/types.rs
@@ -121,6 +121,7 @@ pub enum Message {
     HttpEnabled(bool),
     SocksPortChanged(String),
     SocksHostChanged(String),
+    SocksOutproxyHostChanged(String),
     SocksEnabled(bool),
     FloodfillEnabled(bool),
     TransitTunnelCountChanged(String),


### PR DESCRIPTION
Outproxy can be specified with `--socks-outproxy` or via the router configuration:

```toml
[socks-proxy]
port = 4447
host = "127.0.0.1"
outproxy = "127.0.0.1:9050"
```