### PR TITLE
fix(core): use checked_sub to prevent duration overflow panic in Profile

### DIFF
--- a/emissary-core/src/profile.rs
+++ b/emissary-core/src/profile.rs
@@ -145,7 +145,11 @@ impl Profile {
     fn has_recently_declined<R: Runtime>(&self) -> bool {
         self.last_declined.map_or_else(
             || false,
-            |last_declined| R::time_since_epoch() - last_declined < LAST_DECLINE_THRESHOLD,
+            |last_declined| {
+                R::time_since_epoch()
+                    .checked_sub(last_declined)
+                    .is_some_and(|elapsed| elapsed < LAST_DECLINE_THRESHOLD)
+            },
         )
     }
 
@@ -177,7 +181,9 @@ impl Profile {
         self.last_dial_failure.map_or_else(
             || false,
             |last_dial_failure| {
-                R::time_since_epoch() - last_dial_failure > UNREACHABILITY_THRESHOLD
+                R::time_since_epoch()
+                    .checked_sub(last_dial_failure)
+                    .is_some_and(|elapsed| elapsed > UNREACHABILITY_THRESHOLD)
             },
         )
     }


### PR DESCRIPTION
Fixes #339

## Problem

`Profile::has_recently_declined()` and `Profile::is_unreachable()` 
panic with "overflow when subtracting durations" when stored timestamps 
from a previous session are larger than the current `time_since_epoch()`.

This happens reliably on the second launch after profile data has been 
persisted from the first session.

## Changes

Two lines changed in `emissary-core/src/profile.rs`:

**has_recently_declined() (~line 148):**
```rust
// Before (panics):
R::time_since_epoch() - last_declined < LAST_DECLINE_THRESHOLD

// After (safe):
R::time_since_epoch()
    .checked_sub(last_declined)
    .map_or(false, |elapsed| elapsed < LAST_DECLINE_THRESHOLD)
```

**is_unreachable() (~line 180):**
```rust
// Before (panics):
R::time_since_epoch() - last_dial_failure > UNREACHABILITY_THRESHOLD

// After (safe):
R::time_since_epoch()
    .checked_sub(last_dial_failure)
    .map_or(false, |elapsed| elapsed > UNREACHABILITY_THRESHOLD)
```

When `checked_sub` returns `None` (timestamp in the future), both 
functions return `false` - treating the router as neither recently 
declined nor unreachable. This is the safe default.

## Testing

- Tested on Linux (Ubuntu 24/WSL2) and Windows 11
- Router starts, runs, stops, restarts without panic
- Compiled with `cargo build --release` - zero warnings