### PR TITLE
core: fix inverted comparison in `Profile::is_unreachable`

### DIFF
--- a/emissary-core/src/profile.rs
+++ b/emissary-core/src/profile.rs
@@ -183,7 +183,7 @@ impl Profile {
             |last_dial_failure| {
                 R::time_since_epoch()
                     .checked_sub(last_dial_failure)
-                    .is_some_and(|elapsed| elapsed > UNREACHABILITY_THRESHOLD)
+                    .is_some_and(|elapsed| elapsed < UNREACHABILITY_THRESHOLD)
             },
         )
     }


### PR DESCRIPTION
## Summary

`Profile::is_unreachable` used `elapsed > UNREACHABILITY_THRESHOLD`, which inverts the documented cooldown semantics ("how long the router is considered unreachable after last dial failure"). Sibling predicate `has_recently_declined` uses `<`, matching the constant docs. Flipping the operator restores the intended behavior.

As written, the bug poisons hop selection via `is_failing()` → `tunnel/pool/selector.rs` (10 call sites):

- Routers with a **recent** dial failure slip through the filter (30 s < 180 s → treated as reachable).
- Routers with an **old** failure become permanently blacklisted, because `last_dial_failure` is never cleared on successful reconnects, so `elapsed > 180 s` stays true forever after one failure hours ago.

## How it was found

Surfaced by an AI-assisted multi-agent code review (ultrareview) targeting SSU2 / profile code. Orthogonal to the SSU2 shutdown audit that the review was opened for, but the review exposed this one-line fix in a closure touched by #342.

## Test plan

- [x] `cargo check -p emissary-core` passes
- [x] Existing transport/profile tests pass (same pass/fail counts as master on this Windows host; the pre-existing flakes in ntcp2/ssu2 loopback tests are unrelated)
- [ ] Reviewer sanity-check of selector.rs call-site semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)