### PR TITLE
core: align ACK-with-ranges declared size with bytes actually written

### DIFF
--- a/emissary-core/src/transport/ssu2/message/data.rs
+++ b/emissary-core/src/transport/ssu2/message/data.rs
@@ -741,17 +741,20 @@ impl<'a> DataMessageBuilder<'a> {
                     out.put_u8(num_acks);
                 }
                 Some((ack_through, num_acks, Some(ranges))) if bytes_left > ACK_BLOCK_MIN_SIZE => {
+                    // Cap the pair count by both the ranges available and the remaining
+                    // payload budget so the declared size matches the bytes actually written.
+                    let num_ranges =
+                        ranges.len().min(bytes_left.saturating_sub(ACK_BLOCK_MIN_SIZE) / 2);
+
                     out.put_u8(BlockType::Ack.as_u8());
-                    out.put_u16((5usize + ranges.len() * 2) as u16);
+                    out.put_u16((5usize + num_ranges * 2) as u16);
                     out.put_u32(ack_through);
                     out.put_u8(num_acks);
 
-                    ranges.iter().take(bytes_left.saturating_sub(ACK_BLOCK_MIN_SIZE) / 2).for_each(
-                        |(nack, ack)| {
-                            out.put_u8(*nack);
-                            out.put_u8(*ack);
-                        },
-                    );
+                    ranges.iter().take(num_ranges).for_each(|(nack, ack)| {
+                        out.put_u8(*nack);
+                        out.put_u8(*ack);
+                    });
                 }
                 _ => {}
             }


### PR DESCRIPTION
## Summary

`DataMessageBuilder` wrote the SSU2 ACK block's declared size from `ranges.len()` but then truncated the body with `take(bytes_left - ACK_BLOCK_MIN_SIZE / 2)`. When the remaining payload budget couldn't fit every range, the declared size overstated the body, and the receiver's \`parse_ack\` (which consumes exactly \`size - 5\` bytes from the buffer) pulled bytes out of the following block. That misaligned every subsequent block boundary (Termination, I2NP, PeerTest, Relay, Padding) in the same packet, so those blocks were silently lost or mis-decoded.

This patch computes the final pair count once, capped by both `ranges.len()` and the remaining payload budget, and uses it for both the size field and the write loop so declaration and body always agree. The non-truncated path is bit-identical to the previous code.

## Trigger conditions

- `max_payload_size` is tight, e.g. the `FirstFragment`/`FollowOnFragment` case in `transmission.rs:561` chunks I2NP payloads into 1200-byte chunks; with a 1472-byte MTU, ~228 bytes remain for the ACK block, fitting only 110 pairs.
- `RemoteAckManager::ack_info()` can return up to ~128 pairs (from `MAX_ACK_DIFF = 255`).
- Any path where `ranges.len() * 2 + ACK_BLOCK_MIN_SIZE > bytes_left` triggers the mismatch. The `MIN_MTU = 512` throttling path widens the window.

## How it was found

Surfaced by an AI-assisted multi-agent code review (ultrareview) looking at SSU2 transport shutdown behavior. The clippy/fmt refactor in \`d9f3c45\` converted this arm from \`if\` to a match guard but left the size/truncation asymmetry untouched.

## Test plan

- [x] \`cargo check -p emissary-core\` passes
- [x] Existing \`transport::ssu2::message::data::tests::immediate_ack\` still passes (non-truncation path is unchanged)
- [ ] Reviewer may want to add a regression test for the \`ranges.len() * 2 + 8 > bytes_left\` case

🤖 Generated with [Claude Code](https://claude.com/claude-code)