### PR TITLE
core+util: stop a per-packet UDP error from shutting the router down (fixes #340)

### DIFF
--- a/emissary-core/src/transport/mod.rs
+++ b/emissary-core/src/transport/mod.rs
@@ -215,6 +215,7 @@ impl<R: Runtime> TransportManagerBuilder<R> {
             supported_transports: self.supported_transports,
             transit_tunnels_disabled: self.transit_tunnels_disabled,
             transports: self.transports,
+            terminated_transports: HashSet::new(),
             transport_tx: self.transport_tx.clone(),
         }
     }
@@ -349,6 +350,10 @@ pub struct TransportManager<R: Runtime> {
 
     /// Enabled transports.
     transports: Vec<Box<dyn Transport<Item = TransportEvent>>>,
+
+    /// Indices in `transports` whose stream has terminated. Skipped by the poll loop; the
+    /// manager keeps running as long as at least one transport is alive.
+    terminated_transports: HashSet<usize>,
 }
 
 impl<R: Runtime> TransportManager<R> {
@@ -1137,16 +1142,44 @@ impl<R: Runtime> Future for TransportManager<R> {
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = Pin::into_inner(self);
         let len = this.transports.len();
+
+        if len > 0 && this.terminated_transports.len() >= len {
+            return Poll::Ready(());
+        }
+
         let start_index = this.poll_index;
 
         loop {
             let index = this.poll_index % len;
             this.poll_index += 1;
 
+            if this.terminated_transports.contains(&index) {
+                if this.poll_index == start_index + len {
+                    break;
+                }
+                continue;
+            }
+
             loop {
                 match this.transports[index].poll_next_unpin(cx) {
                     Poll::Pending => break,
-                    Poll::Ready(None) => return Poll::Ready(()),
+                    Poll::Ready(None) => {
+                        tracing::error!(
+                            target: LOG_TARGET,
+                            %index,
+                            total_transports = len,
+                            "transport stream ended",
+                        );
+                        this.terminated_transports.insert(index);
+                        if this.terminated_transports.len() >= len {
+                            tracing::error!(
+                                target: LOG_TARGET,
+                                "all transports terminated, shutting down transport manager",
+                            );
+                            return Poll::Ready(());
+                        }
+                        break;
+                    }
                     Poll::Ready(Some(TransportEvent::ConnectionEstablished {
                         address,
                         direction,

--- a/emissary-util/src/runtime/tokio.rs
+++ b/emissary-util/src/runtime/tokio.rs
@@ -281,7 +281,24 @@ impl UdpSocket for TokioUdpSocket {
         buf: &[u8],
         target: SocketAddr,
     ) -> Poll<Option<usize>> {
-        Poll::Ready(futures::ready!(self.socket.poll_send_to(cx, buf, target)).ok())
+        // A per-packet send error (e.g. NetworkUnreachable when dialing an IPv6 peer from a
+        // host without IPv6 connectivity) does not mean the UDP socket is permanently dead —
+        // it just means this datagram didn't go out. Report 0 bytes sent so the upper
+        // protocol treats it as a dropped packet and retransmits, rather than tearing down
+        // the session / transport / router.
+        match futures::ready!(self.socket.poll_send_to(cx, buf, target)) {
+            Ok(n) => Poll::Ready(Some(n)),
+            Err(err) => {
+                tracing::debug!(
+                    target: LOG_TARGET,
+                    kind = ?err.kind(),
+                    raw_os_error = ?err.raw_os_error(),
+                    %target,
+                    "UDP send failed, dropping datagram",
+                );
+                Poll::Ready(Some(0))
+            }
+        }
     }
 
     #[inline]
@@ -293,7 +310,19 @@ impl UdpSocket for TokioUdpSocket {
         let mut buf = ReadBuf::new(buf);
 
         match futures::ready!(self.socket.poll_recv_from(cx, &mut buf)) {
-            Err(_) => Poll::Ready(None),
+            Err(err) => {
+                // A per-datagram recv error (e.g. ConnectionReset on Windows when a prior
+                // send triggered an ICMP port-unreachable) is not terminal — the tokio
+                // socket registration has already installed our waker, so returning
+                // Pending schedules us for the next read event.
+                tracing::debug!(
+                    target: LOG_TARGET,
+                    kind = ?err.kind(),
+                    raw_os_error = ?err.raw_os_error(),
+                    "UDP recv failed, ignoring",
+                );
+                Poll::Pending
+            }
             Ok(from) => {
                 let nread = buf.filled().len();
                 Poll::Ready(Some((nread, from)))


### PR DESCRIPTION
## Summary

Fixes #340 — router self-terminates shortly after startup on dual-stack hosts without working IPv6 connectivity. The shutdown cascades through **four layers** that each escalate "one packet didn't go" into a more fatal signal, until the whole router exits. Root cause is in the bottom layer; a defense-in-depth fix is added one layer up.

### Cascade

| Layer | File | Bug |
|---|---|---|
| 1 | `emissary-util/src/runtime/tokio.rs` | `TokioUdpSocket::poll_send_to` treated any `io::Error` as `Poll::Ready(None)` via `.ok()`, conflating "this datagram failed" with "socket is permanently dead" |
| 2 | `ssu2/session/pending/outbound.rs` | Treats `Ready(None)` from its socket as `PendingSsu2SessionStatus::SocketClosed`, giving up the session |
| 3 | `ssu2/socket.rs` | Treats any pending-session `SocketClosed` as `Ready(None)`, giving up the whole SSU2 transport |
| 4 | `transport/mod.rs` | Treats any transport returning `None` as `Ready(())`, shutting down the router even when NTCP2 is healthy |

**Trigger:** outbound SSU2 send to an IPv6 bootstrap peer when the host has no IPv6 route. `sendto` returns `NetworkUnreachable` (Windows: `WSAENETUNREACH`, 10051; Linux: `ENETUNREACH`), and the cascade fires within milliseconds of startup. The reporter's "approximately 9 minutes" in #340 is the time until their machine happened to dial an IPv6-only peer.

## Fix

**Layer 1 — root cause (`emissary-util/src/runtime/tokio.rs`):** a per-datagram error is not socket death. `poll_send_to` now logs the error and returns `Some(0)` so the upper protocol retransmits. `poll_recv_from` returns `Pending` on per-datagram errors — tokio's socket registration has already installed the waker, so we're scheduled for the next read event (handles e.g. Windows `ConnectionReset` after ICMP port-unreachable).

**Layer 4 — defense in depth (`emissary-core/src/transport/mod.rs`):** `TransportManager::poll` now tracks terminated transport indices in a `HashSet` and skips them in the round-robin poll. Returns `Ready(())` only when **every** transport has terminated. A failed SSU2 stream no longer drags NTCP2 down with it.

## Reproduction & verification

Before fix, on a Windows 11 host with IPv4 but no working IPv6 route:

```
emissary-cli --disable-ui --socks-proxy-port 4448
```

with a fresh `~/.emissary` consistently exits within **1–3 seconds** of startup (exit 0, log contains `TrySendError::Closed` on the transport manager channel). Instrumentation traced the shutdown to exactly the cascade above: `WSAENETUNREACH → Poll::Ready(None) → SocketClosed → TransportManager exit`.

After fix, the same machine with the same command:

- **11-minute single stability run:** 0 shutdown signatures, 12+ tunnels built and expired normally, SAM socks-proxy session active throughout. Log ends with routine tunnel-pool churn, not shutdown.
- **Cumulative ~15 minutes** across three runs on the same host with the same command.
- `cargo check -p emissary-core -p emissary-util` clean.
- Transport tests: same pass/fail counts on this branch vs. `master` (33 pre-existing Windows loopback-socket flakes, not caused by this change).

## How it was found

The original bug hunt was opened as an AI-assisted multi-agent review (ultrareview) of SSU2 transport code for #340. The review surfaced two orthogonal pre-existing bugs (submitted as #349 and #350), but neither was the cause of #340. A follow-up investigation added trace logging at each `Ready(None)` site in the cascade and pinpointed the `NetworkUnreachable` at the runtime wrapper.

## Test plan

- [x] Fresh-install reproduction no longer exits early (11-min run clean)
- [x] Compilation clean across workspace
- [x] No new test regressions vs. master
- [ ] Reviewer may want a mock-runtime regression test that injects a transient UDP error and asserts the router survives
- [ ] Reviewer may want to double-check the `poll_recv_from` → `Pending` path against tokio's waker registration guarantees on non-Windows platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)