### PR TITLE
docker: publish linux/arm64 image as well

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,6 +44,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Some benefits of publishing an arm64 image:

* somewhat easier to run on Apple Silicon (it should remove a warning about a different architecture);
* sometimes a cloud ARM image is cheaper (e.g. AWS Graviton instances).

No one's complained about the cost of running this in the cloud, or the lack of ARM support, but it's a simple enough addition that it doesn't really hurt.

linux/arm/v7 fails on:
    
    error[E0277]: the trait bound `u64: ToUsize` is not satisfied
        --> emissary-util/src/su3.rs:209:36
