### PR TITLE
emissary-util: make reseeder TLS pluggable (add rustls option)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2557,8 +2563,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2568,9 +2576,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2973,6 +2983,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3609,6 +3620,12 @@ name = "longest-increasing-subsequence"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3bd0dd2cd90571056fdb71f6275fada10131182f84899f4b2a916e565d81d86"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -4890,6 +4907,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "socket2 0.5.9",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.2",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.12",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.5.9",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5123,6 +5195,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -5130,6 +5203,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5137,6 +5212,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -5144,6 +5220,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -5310,6 +5387,7 @@ checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -5345,6 +5423,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -6252,6 +6331,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6931,6 +7025,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webbrowser"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6988,6 +7092,24 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/emissary-util/Cargo.toml
+++ b/emissary-util/Cargo.toml
@@ -30,7 +30,7 @@ ed25519-dalek = { workspace = true, features = ["rand_core", "fast"] }
 futures = { workspace = true }
 nom = { workspace = true, features = ["alloc"] }
 rand = { workspace = true, features = ["thread_rng"] }
-reqwest = { workspace = true, features = ["default-tls"] }
+reqwest = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 smol = { workspace = true, optional = true }
 socket2 = { workspace = true }
@@ -42,7 +42,13 @@ tracing = { workspace = true, features = ["log"] }
 x25519-dalek = { workspace = true, features = ["getrandom", "static_secrets", "precomputed-tables"] }
 
 [features]
-default = ["tokio"]
+# TLS backend for the HTTPS reseeder. `native-tls` (the default) keeps the
+# existing behaviour (OpenSSL/Schannel/Secure Transport). `rustls` selects a
+# pure-Rust stack so the crate cross-compiles without OpenSSL, e.g. to Android
+# and iOS. Enable exactly one: `default-features = false` + `features = ["rustls"]`.
+default = ["tokio", "native-tls"]
 tokio = ["dep:tokio", "dep:tokio-util"]
 smol = ["dep:smol"]
 metrics = ["dep:metrics", "dep:metrics-exporter-prometheus"]
+native-tls = ["reqwest/default-tls"]
+rustls = ["reqwest/rustls-tls"]

--- a/examples/rust-chat/Cargo.toml
+++ b/examples/rust-chat/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 emissary-core = { path = "../../emissary-core", version = "0.4.0" }
-emissary-util = { path = "../../emissary-util", version = "0.4.0", default-features = false, features = ["tokio"] }
+emissary-util = { path = "../../emissary-util", version = "0.4.0", default-features = false, features = ["tokio", "native-tls"] }
 rand = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/examples/rust-tutorial/Cargo.toml
+++ b/examples/rust-tutorial/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 emissary-core = { path = "../../emissary-core", version = "0.4.0" }
-emissary-util = { path = "../../emissary-util", version = "0.4.0", default-features = false, features = ["tokio"] }
+emissary-util = { path = "../../emissary-util", version = "0.4.0", default-features = false, features = ["tokio", "native-tls"] }
 futures = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }


### PR DESCRIPTION
## Make the reseeder's TLS pluggable (add a `rustls` option)

`emissary-util` pulls `reqwest` with `default-tls` (native-tls), which resolves to OpenSSL on most targets. That blocks cross-compiling the crate to Android and iOS without a full OpenSSL build for the target.

This puts the TLS backend behind two features:

- `native-tls` (**default**) - unchanged, current behavior.
- `rustls` - pure-Rust, no OpenSSL.

The default stays `native-tls`, so this is a no-op for existing users. A mobile build opts in with:

```toml
emissary-util = { version = "0.4", default-features = false, features = ["tokio", "rustls"] }
```

`reqwest`'s `rustls-tls` uses `ring`, which is convenient for apps that already link a rustls stack (e.g. arti/Tor) - one crypto provider, no OpenSSL anywhere.

### Why

We're using the embedded router in a cross-platform app and needed the reseeder to build for mobile. With this change the whole embedded router cross-compiles to `aarch64-linux-android` with no `openssl-sys`/`native-tls` in the tree, and the rustls reseeder works live (reseeds, builds tunnels, yields a destination). Happy to adjust naming or wiring if you'd prefer a different shape.
