### PR TITLE
core: Keep a limited set of routers in memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,32 +91,32 @@ jobs:
     - name: cargo-check rust-chat
       run: cargo check -p rust-chat
 
-  fuzz:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        toolchain: nightly
+  # fuzz:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v6
+  #   - uses: actions-rust-lang/setup-rust-toolchain@v1
+  #     with:
+  #       toolchain: nightly
 
-    - name: Install cargo-fuzz
-      run: cargo install cargo-fuzz
+  #   - name: Install cargo-fuzz
+  #     run: cargo install cargo-fuzz
 
-    - name: cargo-fuzz build
-      working-directory: emissary-core
-      run: cargo +nightly fuzz build
+  #   - name: cargo-fuzz build
+  #     working-directory: emissary-core
+  #     run: cargo +nightly fuzz build
 
-    - name: cargo-fuzz primitives
-      working-directory: emissary-core
-      run: cargo +nightly fuzz run primitives -- -max_total_time=30
+  #   - name: cargo-fuzz primitives
+  #     working-directory: emissary-core
+  #     run: cargo +nightly fuzz run primitives -- -max_total_time=30
 
-    - name: cargo-fuzz i2np
-      working-directory: emissary-core
-      run: cargo +nightly fuzz run i2np -- -max_total_time=30
+  #   - name: cargo-fuzz i2np
+  #     working-directory: emissary-core
+  #     run: cargo +nightly fuzz run i2np -- -max_total_time=30
 
-    - name: cargo-fuzz messages
-      working-directory: emissary-core
-      run: cargo +nightly fuzz run messages -- -max_total_time=30
+  #   - name: cargo-fuzz messages
+  #     working-directory: emissary-core
+  #     run: cargo +nightly fuzz run messages -- -max_total_time=30
 
   test:
     runs-on: ubuntu-latest

--- a/emissary-core/src/destination/lease_set.rs
+++ b/emissary-core/src/destination/lease_set.rs
@@ -1023,7 +1023,7 @@ mod tests {
             3usize,
             netdb_handle,
             noise_ctx,
-            ProfileStorage::new(&[], &[]),
+            ProfileStorage::new(&[], &[], None),
             false,
             Bytes::from(serialized),
         );
@@ -1198,7 +1198,7 @@ mod tests {
             3usize,
             netdb_handle,
             noise_ctx,
-            ProfileStorage::new(&[], &[]),
+            ProfileStorage::new(&[], &[], None),
             false,
             Bytes::from(serialized),
         );
@@ -1380,7 +1380,7 @@ mod tests {
             3usize,
             netdb_handle,
             noise_ctx,
-            ProfileStorage::new(&[], &[]),
+            ProfileStorage::new(&[], &[], None),
             false,
             Bytes::from(serialized),
         );
@@ -1564,7 +1564,7 @@ mod tests {
         let destination_id = lease_set.header.destination.id();
         let key = Bytes::from(destination_id.to_vec());
         let serialized = lease_set.serialize(&signing_key);
-        let profile_storage = ProfileStorage::new(&[], &[]);
+        let profile_storage = ProfileStorage::new(&[], &[], None);
         let mut manager = LeaseSetManager::<MockRuntime>::new(
             tunnels,
             destination_id,
@@ -1802,7 +1802,7 @@ mod tests {
         let destination_id = lease_set.header.destination.id();
         let key = Bytes::from(destination_id.to_vec());
         let serialized = lease_set.serialize(&signing_key);
-        let profile_storage = ProfileStorage::new(&[], &[]);
+        let profile_storage = ProfileStorage::new(&[], &[], None);
         let mut manager = LeaseSetManager::<MockRuntime>::new(
             tunnels,
             destination_id,
@@ -2056,7 +2056,7 @@ mod tests {
         let destination_id = lease_set.header.destination.id();
         let key = Bytes::from(destination_id.to_vec());
         let serialized = lease_set.serialize(&signing_key);
-        let profile_storage = ProfileStorage::new(&[], &[]);
+        let profile_storage = ProfileStorage::new(&[], &[], None);
         let mut manager = LeaseSetManager::<MockRuntime>::new(
             tunnels,
             destination_id,
@@ -2319,7 +2319,7 @@ mod tests {
         let destination_id = lease_set.header.destination.id();
         let key = Bytes::from(destination_id.to_vec());
         let serialized = lease_set.serialize(&signing_key);
-        let profile_storage = ProfileStorage::new(&[], &[]);
+        let profile_storage = ProfileStorage::new(&[], &[], None);
         let mut manager = LeaseSetManager::<MockRuntime>::new(
             tunnels,
             destination_id,
@@ -2573,7 +2573,7 @@ mod tests {
         let tunnels = lease_set.leases.clone();
         let destination_id = lease_set.header.destination.id();
         let serialized = lease_set.serialize(&signing_key);
-        let profile_storage = ProfileStorage::new(&[], &[]);
+        let profile_storage = ProfileStorage::new(&[], &[], None);
         let manager = LeaseSetManager::<MockRuntime>::new(
             tunnels,
             destination_id,
@@ -2656,7 +2656,7 @@ mod tests {
             3usize,
             netdb_handle,
             noise_ctx,
-            ProfileStorage::new(&[], &[]),
+            ProfileStorage::new(&[], &[], None),
             false,
             Bytes::from(serialized),
         );
@@ -2821,7 +2821,7 @@ mod tests {
         let tunnels = lease_set.leases.clone();
         let destination_id = lease_set.header.destination.id();
         let serialized = lease_set.serialize(&signing_key);
-        let profile_storage = ProfileStorage::new(&[], &[]);
+        let profile_storage = ProfileStorage::new(&[], &[], None);
         let mut manager = LeaseSetManager::<MockRuntime>::new(
             tunnels,
             destination_id,
@@ -2886,7 +2886,7 @@ mod tests {
         let destination_id = lease_set.header.destination.id();
         let key = Bytes::from(destination_id.to_vec());
         let serialized = lease_set.serialize(&signing_key);
-        let profile_storage = ProfileStorage::new(&[], &[]);
+        let profile_storage = ProfileStorage::new(&[], &[], None);
         let mut manager = LeaseSetManager::<MockRuntime>::new(
             tunnels.clone(),
             destination_id,

--- a/emissary-core/src/destination/mod.rs
+++ b/emissary-core/src/destination/mod.rs
@@ -1021,7 +1021,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             false,
-            ProfileStorage::new(&[], &[]),
+            ProfileStorage::new(&[], &[], None),
         );
 
         // insert dummy lease set for `remote` into `Destination`
@@ -1055,7 +1055,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             false,
-            ProfileStorage::new(&[], &[]),
+            ProfileStorage::new(&[], &[], None),
         );
 
         // insert lease set which expired 10 seconds ago
@@ -1096,7 +1096,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             false,
-            ProfileStorage::new(&[], &[]),
+            ProfileStorage::new(&[], &[], None),
         );
 
         // query lease set and verify it's not found and that a query has been started
@@ -1126,7 +1126,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             false,
-            ProfileStorage::new(&[], &[]),
+            ProfileStorage::new(&[], &[], None),
         );
 
         // query lease set and verify it's not found and that a query has been started
@@ -1162,7 +1162,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             false,
-            ProfileStorage::new(&[], &[]),
+            ProfileStorage::new(&[], &[], None),
         );
 
         // spam the netdb handle full of queries
@@ -1210,7 +1210,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             false,
-            ProfileStorage::new(&[], &[]),
+            ProfileStorage::new(&[], &[], None),
         );
 
         destination
@@ -1241,7 +1241,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             false,
-            ProfileStorage::new(&[], &[]),
+            ProfileStorage::new(&[], &[], None),
         );
 
         // new inbound tunnel built
@@ -1289,7 +1289,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             true,
-            ProfileStorage::new(&[], &[]),
+            ProfileStorage::new(&[], &[], None),
         );
 
         // insert lease set which expired 10 seconds ago
@@ -1400,7 +1400,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             false,
-            ProfileStorage::new(&[], &[]),
+            ProfileStorage::new(&[], &[], None),
         );
 
         // create remote destination and two leases for it

--- a/emissary-core/src/netdb/dht.rs
+++ b/emissary-core/src/netdb/dht.rs
@@ -328,7 +328,7 @@ mod tests {
             routers,
             RouterContext::new(
                 MockRuntime::register_metrics(vec![], None),
-                ProfileStorage::new(&[], &[]),
+                ProfileStorage::new(&[], &[], None),
                 router_info.identity.id(),
                 Bytes::from(router_info.serialize(&signing_key)),
                 static_key,

--- a/emissary-core/src/netdb/mod.rs
+++ b/emissary-core/src/netdb/mod.rs
@@ -2011,7 +2011,7 @@ mod tests {
 
     #[tokio::test]
     async fn lease_set_store_to_floodfill() {
-        let storage = ProfileStorage::new(&Vec::new(), &Vec::new());
+        let storage = ProfileStorage::new(&Vec::new(), &Vec::new(), None);
         let (tp_handle, _tm_rx, _tp_tx, _srx) = TunnelPoolHandle::create();
 
         // add few floodfills to router storage
@@ -2140,7 +2140,7 @@ mod tests {
 
     #[tokio::test]
     async fn lease_set_store_to_non_floodfill() {
-        let storage = ProfileStorage::new(&Vec::new(), &Vec::new());
+        let storage = ProfileStorage::new(&Vec::new(), &Vec::new(), None);
         let (tp_handle, _tm_rx, _tp_tx, _srx) = TunnelPoolHandle::create();
 
         // add few floodfills to router storage
@@ -2237,7 +2237,7 @@ mod tests {
 
     #[tokio::test]
     async fn expired_lease_set_store() {
-        let storage = ProfileStorage::new(&Vec::new(), &Vec::new());
+        let storage = ProfileStorage::new(&Vec::new(), &Vec::new(), None);
         let (tp_handle, _tm_rx, _tp_tx, _srx) = TunnelPoolHandle::create();
 
         // add few floodfills to router storage
@@ -2336,7 +2336,7 @@ mod tests {
 
     #[tokio::test]
     async fn expired_lease_sets_are_pruned() {
-        let storage = ProfileStorage::new(&Vec::new(), &Vec::new());
+        let storage = ProfileStorage::new(&Vec::new(), &Vec::new(), None);
         let (tp_handle, _tm_rx, _tp_tx, _srx) = TunnelPoolHandle::create();
 
         // add few floodfills to router storage
@@ -2636,7 +2636,7 @@ mod tests {
 
     #[tokio::test]
     async fn router_info_store_to_floodfill() {
-        let storage = ProfileStorage::new(&Vec::new(), &Vec::new());
+        let storage = ProfileStorage::new(&Vec::new(), &Vec::new(), None);
         let (tp_handle, _tm_rx, _tp_tx, _srx) = TunnelPoolHandle::create();
 
         // add few floodfills to router storage
@@ -2761,7 +2761,7 @@ mod tests {
 
     #[tokio::test]
     async fn stale_router_info_not_stored_nor_flooded() {
-        let storage = ProfileStorage::new(&Vec::new(), &Vec::new());
+        let storage = ProfileStorage::new(&Vec::new(), &Vec::new(), None);
         let (tp_handle, _tm_rx, _tp_tx, _srx) = TunnelPoolHandle::create();
 
         // add few floodfills to router storage
@@ -2850,7 +2850,7 @@ mod tests {
 
     #[tokio::test]
     async fn lease_set_query() {
-        let storage = ProfileStorage::new(&Vec::new(), &Vec::new());
+        let storage = ProfileStorage::new(&Vec::new(), &Vec::new(), None);
         let (tp_handle, tm_rx, _tp_tx, _srx) = TunnelPoolHandle::create();
 
         // add few floodfills to router storage
@@ -2971,7 +2971,7 @@ mod tests {
 
     #[tokio::test]
     async fn lease_set_query_value_not_found() {
-        let storage = ProfileStorage::new(&Vec::new(), &Vec::new());
+        let storage = ProfileStorage::new(&Vec::new(), &Vec::new(), None);
         let (tp_handle, tm_rx, _tp_tx, _srx) = TunnelPoolHandle::create();
 
         // add few floodfills to router storage
@@ -3057,7 +3057,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn router_info_query() {
-        let storage = ProfileStorage::new(&Vec::new(), &Vec::new());
+        let storage = ProfileStorage::new(&Vec::new(), &Vec::new(), None);
         let (tp_handle, tm_rx, _tp_tx, _srx) = TunnelPoolHandle::create();
 
         // add few floodfills to router storage
@@ -3197,7 +3197,7 @@ mod tests {
 
     #[tokio::test]
     async fn router_info_query_value_not_found() {
-        let storage = ProfileStorage::new(&Vec::new(), &Vec::new());
+        let storage = ProfileStorage::new(&Vec::new(), &Vec::new(), None);
         let (tp_handle, tm_rx, _tp_tx, _srx) = TunnelPoolHandle::create();
 
         // add few floodfills to router storage
@@ -3305,7 +3305,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn pending_messages_sent_when_floodfill_connects() {
-        let storage = ProfileStorage::new(&Vec::new(), &Vec::new());
+        let storage = ProfileStorage::new(&Vec::new(), &Vec::new(), None);
         let (tp_handle, _tm_rx, _tp_tx, _srx) = TunnelPoolHandle::create();
 
         // add few floodfills to router storage
@@ -3401,7 +3401,7 @@ mod tests {
 
     #[tokio::test]
     async fn router_info_with_different_network_id_ignored() {
-        let storage = ProfileStorage::new(&Vec::new(), &Vec::new());
+        let storage = ProfileStorage::new(&Vec::new(), &Vec::new(), None);
         let (tp_handle, _tm_rx, _tp_tx, _srx) = TunnelPoolHandle::create();
 
         // add few floodfills to router storage
@@ -3489,7 +3489,7 @@ mod tests {
 
     #[tokio::test]
     async fn lease_set_store_with_zero_reply_token() {
-        let storage = ProfileStorage::new(&Vec::new(), &Vec::new());
+        let storage = ProfileStorage::new(&Vec::new(), &Vec::new(), None);
         let (tp_handle, _tm_rx, _tp_tx, _srx) = TunnelPoolHandle::create();
 
         // add few floodfills to router storage
@@ -3581,7 +3581,7 @@ mod tests {
 
     #[tokio::test]
     async fn router_info_store_with_zero_reply_token() {
-        let storage = ProfileStorage::new(&Vec::new(), &Vec::new());
+        let storage = ProfileStorage::new(&Vec::new(), &Vec::new(), None);
         let (tp_handle, _tm_rx, _tp_tx, _srx) = TunnelPoolHandle::create();
 
         // add few floodfills to router storage
@@ -3670,7 +3670,7 @@ mod tests {
 
     #[tokio::test]
     async fn recursive_lease_set_query_with_duplicate_floodfills() {
-        let storage = ProfileStorage::new(&Vec::new(), &Vec::new());
+        let storage = ProfileStorage::new(&Vec::new(), &Vec::new(), None);
         let (tp_handle, tm_rx, _tp_tx, _srx) = TunnelPoolHandle::create();
 
         // add few floodfills to router storage
@@ -3839,7 +3839,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn local_router_info_store() {
-        let storage = ProfileStorage::new(&Vec::new(), &Vec::new());
+        let storage = ProfileStorage::new(&Vec::new(), &Vec::new(), None);
         let (tp_handle, _tm_rx, _tp_tx, _srx) = TunnelPoolHandle::create();
 
         // add few floodfills to router storage
@@ -3955,7 +3955,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn router_exploration_works() {
-        let storage = ProfileStorage::new(&Vec::new(), &Vec::new());
+        let storage = ProfileStorage::new(&Vec::new(), &Vec::new(), None);
         let (tp_handle, tm_rx, _tp_tx, _srx) = TunnelPoolHandle::create();
 
         // add few floodfills to router storage
@@ -4025,7 +4025,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn duplicate_lease_set_query() {
-        let storage = ProfileStorage::new(&Vec::new(), &Vec::new());
+        let storage = ProfileStorage::new(&Vec::new(), &Vec::new(), None);
         let (tp_handle, _tm_rx, _tp_tx, _srx) = TunnelPoolHandle::create();
 
         // add few floodfills to router storage
@@ -4102,7 +4102,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn duplicate_router_info_query() {
-        let storage = ProfileStorage::new(&Vec::new(), &Vec::new());
+        let storage = ProfileStorage::new(&Vec::new(), &Vec::new(), None);
         let (tp_handle, _tm_rx, _tp_tx, _srx) = TunnelPoolHandle::create();
 
         // add few floodfills to router storage
@@ -4180,7 +4180,7 @@ mod tests {
 
     #[tokio::test]
     async fn floodfill_is_ibgw() {
-        let storage = ProfileStorage::new(&Vec::new(), &Vec::new());
+        let storage = ProfileStorage::new(&Vec::new(), &Vec::new(), None);
         let (tp_handle, _tm_rx, _tp_tx, _srx) = TunnelPoolHandle::create();
 
         // add few floodfills to router storage

--- a/emissary-core/src/primitives/capabilities.rs
+++ b/emissary-core/src/primitives/capabilities.rs
@@ -141,7 +141,7 @@ impl Capabilities {
     pub fn parse(caps: &Str) -> Option<Self> {
         let bandwidth = Bandwidth::parse(caps);
         let floodfill = caps.contains("f");
-        let usable = !(caps.contains("E") || caps.contains("G"));
+        let usable = !caps.contains("G");
         let reachable = !(caps.contains("U") || caps.contains("H"));
 
         Some(Self {
@@ -224,7 +224,7 @@ mod tests {
     #[test]
     fn usable() {
         assert!(!Capabilities::parse(&Str::from("LG")).unwrap().is_usable());
-        assert!(!Capabilities::parse(&Str::from("LE")).unwrap().is_usable());
+        assert!(Capabilities::parse(&Str::from("LE")).unwrap().is_usable());
     }
 
     #[test]

--- a/emissary-core/src/profile.rs
+++ b/emissary-core/src/profile.rs
@@ -19,7 +19,7 @@
 use crate::{
     crypto::{base64_decode, base64_encode},
     primitives::{RouterId, RouterInfo},
-    runtime::Runtime,
+    runtime::{Instant, Runtime, Storage},
 };
 
 use bytes::Bytes;
@@ -47,11 +47,19 @@ const UNREACHABILITY_THRESHOLD: Duration = Duration::from_secs(180);
 /// How often [`ProfileManager`] sorts profiles.
 const PROFILE_STORAGE_MAINTENANCE_INTERVAL: Duration = Duration::from_secs(60);
 
+/// Profile storage backup interval.
+///
+/// How often is a backup taken of [`ProfileStorage`].
+const PROFILE_STORAGE_BACKUP_INTERVAL: Duration = Duration::from_secs(15 * 60);
+
 /// How many routers does the high capacity bucket hold.
-const NUM_HIGH_CAPACITY_ROUTERS: usize = 100usize;
+const NUM_HIGH_CAPACITY_ROUTERS: usize = 200usize;
 
 /// How many routers does the standard bucket hold.
-const NUM_STANDARD_ROUTERS: usize = 300usize;
+const NUM_STANDARD_ROUTERS: usize = 400usize;
+
+/// How many routers does the untracked bucket hold.
+const NUM_UNTRACKED_ROUTERS: usize = 2000usize;
 
 /// Router bucket.
 pub enum Bucket {
@@ -71,6 +79,9 @@ pub enum Bucket {
 /// Router profile.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Profile {
+    /// Is there an active connection to the router.
+    pub is_connected: bool,
+
     /// Last activity, duration since UNIX epoch.
     pub last_activity: Duration,
 
@@ -124,6 +135,7 @@ impl Profile {
         Self {
             last_activity: Duration::from_secs(0),
             last_declined: None,
+            is_connected: false,
             last_dial_failure: None,
             num_accepted: 0usize,
             num_connection: 0usize,
@@ -137,6 +149,70 @@ impl Profile {
             num_test_successes: 0usize,
             num_unaswered: 0usize,
         }
+    }
+
+    /// Create new [`Profile`] with `last_activity` set to now.
+    fn new_with_activity<R: Runtime>() -> Self {
+        Self {
+            last_activity: R::time_since_epoch(),
+            is_connected: false,
+            last_declined: None,
+            last_dial_failure: None,
+            num_accepted: 0usize,
+            num_connection: 0usize,
+            num_dial_failures: 0usize,
+            num_lookup_failures: 0usize,
+            num_lookup_no_responses: 0usize,
+            num_lookup_successes: 0usize,
+            num_rejected: 0usize,
+            num_selected: 0usize,
+            num_test_failures: 0usize,
+            num_test_successes: 0usize,
+            num_unaswered: 0usize,
+        }
+    }
+
+    /// Is the router considered always inactive.
+    ///
+    /// The router is considered always inactive if it's at least 30 minutes old and has had no
+    /// recorded activity.
+    fn is_always_inactive(&self) -> bool {
+        if self.last_activity < Duration::from_secs(30 * 60) {
+            return false;
+        }
+
+        self.last_declined.is_none()
+            && self.last_dial_failure.is_none()
+            && self.num_accepted == 0usize
+            && self.num_connection == 0usize
+            && self.num_dial_failures == 0usize
+            && self.num_lookup_failures == 0usize
+            && self.num_lookup_no_responses == 0usize
+            && self.num_lookup_successes == 0usize
+            && self.num_rejected == 0usize
+            && self.num_selected == 0usize
+            && self.num_test_failures == 0usize
+            && self.num_test_successes == 0usize
+            && self.num_unaswered == 0usize
+    }
+
+    /// Is the router considered always unreachable.
+    ///
+    /// If the router has had more than 5 dial failures with no successes, the router is considered
+    /// always unreachable.
+    fn is_always_unreachable(&self) -> bool {
+        self.num_dial_failures > 5 && self.num_connection == 0
+    }
+
+    /// Is the router considered "recently inactive".
+    ///
+    /// If the router hasn't had any activity in the last 2 hours, it's considered recently
+    /// inactive.
+    ///
+    /// This is different from `is_always_inactive()` as the router may have had activity at some
+    /// point in time but hasn't any activity in the last 2 hours and is not actively connected.
+    fn is_recently_inactive(&self) -> bool {
+        self.last_activity > Duration::from_secs(2 * 60 * 60) && !self.is_connected
     }
 
     /// Has the router recently declined a tunnel.
@@ -264,22 +340,29 @@ pub struct ProfileStorage<R: Runtime> {
     /// Untracked routers.
     untracked: Arc<RwLock<HashSet<RouterId>>>,
 
+    /// Object providing storage access, if provided.
+    storage: Option<Arc<dyn Storage>>,
+
     /// Marker for `Runtime`.
     _runtime: PhantomData<R>,
 }
 
 impl<R: Runtime> ProfileStorage<R> {
     /// Create new [`ProfileStorage`].
-    pub fn new(routers: &[Vec<u8>], profiles: &[(String, Profile)]) -> Self {
+    pub fn new(
+        routers: &[Vec<u8>],
+        profiles: &[(String, Profile)],
+        storage: Option<Arc<dyn Storage>>,
+    ) -> Self {
         tracing::info!(
             target: LOG_TARGET,
             num_routers = ?routers.len(),
             num_profiles = ?profiles.len(),
-            "initialize profile storage",
+            "initializing profile storage",
         );
 
         // TODO: not good
-        let (routers, raw_router_infos): (HashMap<_, _>, HashMap<_, _>) = routers
+        let (mut routers, mut raw_router_infos): (HashMap<_, _>, HashMap<_, _>) = routers
             .iter()
             .filter_map(|router| {
                 RouterInfo::parse::<R>(router)
@@ -324,6 +407,7 @@ impl<R: Runtime> ProfileStorage<R> {
             })
             .unzip();
 
+        // split routers into fast and untracked buckets
         let (fast, untracked) = {
             let (total, routers, untracked) = fast.iter().flatten().fold(
                 (0f64, HashSet::<RouterId>::new(), HashSet::<RouterId>::new()),
@@ -368,6 +452,7 @@ impl<R: Runtime> ProfileStorage<R> {
                 let untracked = routers
                     .into_iter()
                     .filter_map(|(router_id, _)| (!fast.contains(&router_id)).then_some(router_id))
+                    .chain(untracked)
                     .collect();
 
                 (fast, untracked)
@@ -376,6 +461,7 @@ impl<R: Runtime> ProfileStorage<R> {
 
         let standard = standard.into_iter().flatten().chain(untracked).collect::<HashSet<_>>();
 
+        // split routers into standard and untracked buckets
         let (standard, untracked) = {
             let (total, routers, untracked) = standard.iter().fold(
                 (0f64, HashSet::<RouterId>::new(), HashSet::<RouterId>::new()),
@@ -422,26 +508,105 @@ impl<R: Runtime> ProfileStorage<R> {
                     .filter_map(|(router_id, _)| {
                         (!standard.contains(&router_id)).then_some(router_id)
                     })
+                    .chain(untracked)
                     .collect();
 
                 (standard, untracked)
             }
         };
 
-        let storage = Self {
+        // cull the untracked bucket down to 2000 routers
+        let untracked = {
+            let untracked = untracked.into_iter().collect::<Vec<_>>();
+            let mut total = 0f64;
+            let tracked = untracked
+                .iter()
+                .cloned()
+                .filter_map(|router_id| {
+                    profiles.get(&router_id).expect("to exist").participation_rate().map(|rate| {
+                        total += rate;
+                        router_id
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            if tracked.is_empty() {
+                untracked.into_iter().take(NUM_UNTRACKED_ROUTERS).collect::<HashSet<_>>()
+            } else {
+                let avg = total / tracked.len() as f64;
+                let mut tracked = tracked
+                    .into_iter()
+                    .map(|router_id| {
+                        // profile must exist since the router's participation rate was calculated
+                        let rate = profiles
+                            .get(&router_id)
+                            .expect("to exist")
+                            .weighted_participation_rate(avg);
+
+                        (router_id, rate)
+                    })
+                    .collect::<Vec<_>>();
+
+                tracked.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+                tracked
+                    .iter()
+                    .take(NUM_UNTRACKED_ROUTERS)
+                    .map(|(router_id, _)| router_id.clone())
+                    .collect::<HashSet<_>>()
+            }
+        };
+
+        // remove all routers that were not included in any of the buckets
+        {
+            let router_ids = routers
+                .iter()
+                .flat_map(|(router_id, _)| {
+                    (!fast.contains(router_id)
+                        && !standard.contains(router_id)
+                        && !untracked.contains(router_id))
+                    .then(|| router_id.clone())
+                })
+                .collect::<Vec<_>>();
+
+            let router_ids = router_ids
+                .into_iter()
+                .map(|router_id| {
+                    routers.remove(&router_id);
+                    raw_router_infos.remove(&router_id);
+                    profiles.remove(&router_id);
+
+                    base64_encode(router_id.to_vec())
+                })
+                .collect::<Vec<_>>();
+
+            if let Some(ref storage) = storage {
+                storage.remove_from_disk(router_ids);
+            }
+        }
+
+        tracing::info!(
+            target: LOG_TARGET,
+            num_fast = fast.len(),
+            num_standard = standard.len(),
+            num_untracked = untracked.len(),
+            "profile storage initialized"
+        );
+
+        let profile_storage = Self {
             discovered_routers: Default::default(),
             fast: Arc::new(RwLock::new(fast)),
             profiles: Arc::new(RwLock::new(profiles)),
             raw_router_infos: Arc::new(RwLock::new(raw_router_infos)),
             routers: Arc::new(RwLock::new(routers)),
             standard: Arc::new(RwLock::new(standard)),
+            storage,
             untracked: Arc::new(RwLock::new(untracked)),
             _runtime: Default::default(),
         };
 
-        R::spawn(ProfileManager::<R>::new(storage.clone()).run());
+        R::spawn(ProfileManager::<R>::new(profile_storage.clone()).run());
 
-        storage
+        profile_storage
     }
 
     /// Insert `router` into [`ProfileStorage`].
@@ -462,7 +627,7 @@ impl<R: Runtime> ProfileStorage<R> {
         }
 
         if self.routers.write().insert(router_id.clone(), router_info).is_none() {
-            self.profiles.write().insert(router_id, Profile::new());
+            self.profiles.write().insert(router_id, Profile::new_with_activity::<R>());
         }
 
         true
@@ -605,6 +770,7 @@ impl<R: Runtime> ProfileStorage<R> {
         let profile = inner.get_mut(router_id).expect("to exist");
 
         profile.num_selected += 1;
+        profile.last_activity = R::time_since_epoch();
     }
 
     /// Record that `router_id`'s participation for a tunnel could not be determined.
@@ -687,15 +853,26 @@ impl<R: Runtime> ProfileStorage<R> {
         match inner.get_mut(router_id) {
             Some(profile) => {
                 profile.num_connection += 1;
+                profile.is_connected = true;
                 profile.last_activity = R::time_since_epoch();
             }
             None => {
                 let mut profile = Profile::new();
+                profile.is_connected = true;
                 profile.num_connection += 1;
                 profile.last_activity = R::time_since_epoch();
 
                 inner.insert(router_id.clone(), profile);
             }
+        }
+    }
+
+    /// Connection to the router has been closed.
+    pub fn connection_closed(&self, router_id: &RouterId) {
+        let mut inner = self.profiles.write();
+
+        if let Some(profile) = inner.get_mut(router_id) {
+            profile.is_connected = false
         }
     }
 
@@ -749,23 +926,6 @@ impl<R: Runtime> ProfileStorage<R> {
         }
     }
 
-    /// Get backup of [`ProfileStorage`].
-    pub fn backup(&self) -> Vec<(String, Option<Vec<u8>>, Profile)> {
-        let profiles = self.profiles.read().clone();
-        let mut inner = self.discovered_routers.write();
-
-        profiles
-            .into_iter()
-            .map(|(router_id, profile)| {
-                (
-                    base64_encode(router_id.to_vec()),
-                    inner.remove(&router_id),
-                    profile,
-                )
-            })
-            .collect::<Vec<_>>()
-    }
-
     /// Create new [`ProfileStorage`] from random `routers`.
     ///
     /// Only used in tests.
@@ -801,6 +961,7 @@ impl<R: Runtime> ProfileStorage<R> {
             raw_router_infos: Default::default(),
             routers: Arc::new(RwLock::new(routers)),
             standard: Arc::new(RwLock::new(standard.into_iter().flatten().collect())),
+            storage: None,
             untracked: Default::default(),
             _runtime: Default::default(),
         }
@@ -821,6 +982,8 @@ impl<R: Runtime> ProfileManager<R> {
 
     /// Run the event loop of profile manager.
     async fn run(self) {
+        let mut last_backup = R::now();
+
         loop {
             R::delay(PROFILE_STORAGE_MAINTENANCE_INTERVAL).await;
 
@@ -877,13 +1040,16 @@ impl<R: Runtime> ProfileManager<R> {
             let mut fast = HashSet::<RouterId>::new();
             let mut standard = HashSet::<RouterId>::new();
             let mut untracked = HashSet::<RouterId>::new();
+            let mut removed = HashSet::<RouterId>::new();
 
             for (router_id, _) in routers {
                 let Some(router_info) = router_infos.get(&router_id) else {
+                    removed.insert(router_id);
                     continue;
                 };
 
                 if !router_info.is_reachable() {
+                    removed.insert(router_id);
                     continue;
                 }
 
@@ -902,10 +1068,165 @@ impl<R: Runtime> ProfileManager<R> {
 
             untracked.extend(no_profile_routers);
 
+            // remove unusable routers
+            if let Some(ref storage) = self.profile_storage.storage {
+                storage.remove_from_disk(
+                    removed
+                        .into_iter()
+                        .map(|router_id| base64_encode(router_id.to_vec()))
+                        .collect::<Vec<_>>(),
+                );
+            }
+
             // replace old groups with new groups
-            *self.profile_storage.fast.write() = fast;
-            *self.profile_storage.standard.write() = standard;
-            *self.profile_storage.untracked.write() = untracked;
+            {
+                *self.profile_storage.fast.write() = fast;
+                *self.profile_storage.standard.write() = standard;
+                *self.profile_storage.untracked.write() = untracked;
+            }
+            drop(profiles);
+            drop(router_infos);
+
+            if last_backup.elapsed() <= PROFILE_STORAGE_BACKUP_INTERVAL {
+                continue;
+            }
+
+            // cull the set of untracked routers to `NUM_UNTRACKED_ROUTERS`
+            let router_ids = {
+                let inner = self.profile_storage.untracked.read();
+                let profiles = self.profile_storage.profiles.read();
+
+                if inner.len() <= NUM_UNTRACKED_ROUTERS {
+                    Vec::new()
+                } else {
+                    let mut always_inactive = Vec::new();
+                    let mut always_unreachable = Vec::new();
+                    let mut recently_inactive = Vec::new();
+
+                    // first remove always inactive routers
+                    inner.iter().for_each(|router_id| {
+                        if profiles
+                            .get(router_id)
+                            .is_some_and(|profile| profile.is_always_inactive())
+                        {
+                            always_inactive.push(router_id.clone());
+                        }
+                    });
+
+                    // if necessary, remove always unreachable routers
+                    if inner.len() - always_inactive.len() > NUM_UNTRACKED_ROUTERS {
+                        inner.iter().for_each(|router_id| {
+                            if profiles
+                                .get(router_id)
+                                .is_some_and(|profile| profile.is_always_unreachable())
+                            {
+                                always_unreachable.push(router_id.clone());
+                            }
+                        })
+                    }
+
+                    if inner.len() - always_inactive.len() - always_unreachable.len()
+                        > NUM_UNTRACKED_ROUTERS
+                    {
+                        inner.iter().for_each(|router_id| {
+                            if profiles
+                                .get(router_id)
+                                .is_some_and(|profile| profile.is_recently_inactive())
+                            {
+                                recently_inactive.push(router_id.clone());
+                            }
+                        })
+                    }
+
+                    always_inactive
+                        .into_iter()
+                        .chain(always_unreachable)
+                        .chain(recently_inactive)
+                        .collect()
+                }
+            };
+
+            if let Some(ref storage) = self.profile_storage.storage {
+                if !router_ids.is_empty() {
+                    // purge all collections from the removed routers
+                    let router_ids = {
+                        let mut removed = Vec::new();
+                        let mut fast = self.profile_storage.fast.write();
+                        let mut standard = self.profile_storage.standard.write();
+                        let mut untracked = self.profile_storage.untracked.write();
+                        let mut profiles = self.profile_storage.profiles.write();
+                        let mut raw_router_infos = self.profile_storage.raw_router_infos.write();
+                        let mut routers = self.profile_storage.routers.write();
+                        let mut discovered = self.profile_storage.discovered_routers.write();
+
+                        for router_id in router_ids {
+                            if untracked.len() <= NUM_UNTRACKED_ROUTERS {
+                                break;
+                            }
+
+                            let Some(profile) = profiles.get(&router_id) else {
+                                continue;
+                            };
+
+                            let should_remove = !profile.is_connected
+                                && (profile.is_always_inactive()
+                                    || profile.is_always_unreachable()
+                                    || profile.is_recently_inactive());
+
+                            if !should_remove || !untracked.contains(&router_id) {
+                                continue;
+                            }
+
+                            fast.remove(&router_id);
+                            standard.remove(&router_id);
+                            untracked.remove(&router_id);
+                            profiles.remove(&router_id);
+                            raw_router_infos.remove(&router_id);
+                            routers.remove(&router_id);
+                            discovered.remove(&router_id);
+                            removed.push(base64_encode(router_id.to_vec()));
+                        }
+
+                        removed
+                    };
+
+                    storage.remove_from_disk(router_ids);
+                }
+
+                tracing::info!(
+                    target: LOG_TARGET,
+                    num_fast = %self.profile_storage.fast.read().len(),
+                    num_standard = %self.profile_storage.standard.read().len(),
+                    num_untracked = %self.profile_storage.untracked.read().len(),
+                    "profile storage updated",
+                );
+
+                let profiles = self.profile_storage.profiles.read().clone();
+                let mut inner = self.profile_storage.discovered_routers.write();
+
+                let routers = profiles
+                    .into_iter()
+                    .map(|(router_id, profile)| {
+                        (
+                            base64_encode(router_id.to_vec()),
+                            inner.remove(&router_id),
+                            profile,
+                        )
+                    })
+                    .collect::<Vec<_>>();
+
+                if !routers.is_empty() {
+                    tracing::info!(
+                        target: LOG_TARGET,
+                        num_routers = ?routers.len(),
+                        "taking backup of profile storage",
+                    );
+
+                    storage.save_to_disk(routers);
+                }
+            }
+
+            last_backup = R::now();
         }
     }
 }
@@ -926,7 +1247,7 @@ mod tests {
             })
             .unzip();
 
-        let profiles = ProfileStorage::<MockRuntime>::new(&infos, &Vec::new());
+        let profiles = ProfileStorage::<MockRuntime>::new(&infos, &Vec::new(), None);
 
         assert_eq!(profiles.routers.read().len(), 5);
         assert_eq!(profiles.profiles.read().len(), 5);
@@ -956,6 +1277,7 @@ mod tests {
                 (
                     router_id,
                     Profile {
+                        is_connected: false,
                         last_activity: Duration::from_secs((i as u64 + 1) * 10000),
                         last_declined: None,
                         last_dial_failure: None,
@@ -975,7 +1297,7 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        let profiles = ProfileStorage::<MockRuntime>::new(&infos, &profiles);
+        let profiles = ProfileStorage::<MockRuntime>::new(&infos, &profiles, None);
 
         assert_eq!(profiles.routers.read().len(), 5);
         assert_eq!(profiles.profiles.read().len(), 5);
@@ -1009,6 +1331,7 @@ mod tests {
                 (
                     router_id,
                     Profile {
+                        is_connected: false,
                         last_activity: Duration::from_secs((i as u64 + 1) * 10000),
                         last_declined: None,
                         last_dial_failure: None,
@@ -1028,7 +1351,7 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        let profiles = ProfileStorage::<MockRuntime>::new(&Vec::new(), &profiles);
+        let profiles = ProfileStorage::<MockRuntime>::new(&Vec::new(), &profiles, None);
 
         assert!(profiles.routers.read().is_empty());
         assert!(profiles.profiles.read().is_empty());
@@ -1036,7 +1359,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_profile_if_it_doesnt_exist() {
-        let profiles = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profiles = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
         let router_id = RouterId::random();
 
         assert!(profiles.routers.read().is_empty());
@@ -1049,5 +1372,6 @@ mod tests {
             reader.profiles.get(&router_id).unwrap().num_connection,
             1usize
         );
+        assert!(reader.profiles.get(&router_id).unwrap().is_connected);
     }
 }

--- a/emissary-core/src/router/context.rs
+++ b/emissary-core/src/router/context.rs
@@ -225,7 +225,7 @@ pub(crate) mod builder {
                 .metrics_handle
                 .unwrap_or_else(|| <MockRuntime as Runtime>::register_metrics(vec![], None));
             let profile_storage =
-                self.profile_storage.unwrap_or_else(|| ProfileStorage::new(&[], &[]));
+                self.profile_storage.unwrap_or_else(|| ProfileStorage::new(&[], &[], None));
             let (router_info, static_key, signing_key) =
                 self.router_info.unwrap_or_else(|| RouterInfoBuilder::default().build());
             let event_handle = self.event_handle.unwrap_or_else(EventHandle::new_for_tests);

--- a/emissary-core/src/router/mod.rs
+++ b/emissary-core/src/router/mod.rs
@@ -60,12 +60,6 @@ const NET_ID: u8 = 2u8;
 /// immediately, cancelling graceful shutdown.
 const IMMEDIATE_SHUTDOWN_COUNT: usize = 2usize;
 
-/// Profile storage backup interval.
-///
-/// How often is backup (stored to disk) taken of [`ProfileStorage`].
-const PROFILE_STORAGE_BACKUP_INTERVAL: Duration = Duration::from_secs(15 * 60);
-// const PROFILE_STORAGE_BACKUP_INTERVAL: Duration = Duration::from_secs(30);
-
 /// Protocol address information.
 #[derive(Debug, Default, Copy, Clone)]
 pub struct ProtocolAddressInfo {
@@ -226,7 +220,7 @@ impl<R: Runtime> Router<R> {
             ..
         } = config;
 
-        let profile_storage = ProfileStorage::<R>::new(&routers, &profiles);
+        let profile_storage = ProfileStorage::<R>::new(&routers, &profiles, storage.clone());
         let serialized_router_info = local_router_info.serialize(&local_signing_key);
         let local_router_id = local_router_info.identity.id();
         let mut address_info = ProtocolAddressInfo::default();
@@ -413,29 +407,6 @@ impl<R: Runtime> Router<R> {
             address_info.sam_udp = sam_server.udp_local_address();
 
             R::spawn(sam_server)
-        }
-
-        // start profile storage task in the background if it was enabled
-        //
-        // all this task does is periodically backup router infos and profiles to disk
-        if let Some(storage) = storage {
-            R::spawn(async move {
-                loop {
-                    let _ = R::delay(PROFILE_STORAGE_BACKUP_INTERVAL).await;
-
-                    let routers = profile_storage.backup();
-
-                    if !routers.is_empty() {
-                        tracing::info!(
-                            target: LOG_TARGET,
-                            num_routers = ?routers.len(),
-                            "taking backup of profile storage",
-                        );
-
-                        storage.save_to_disk(routers);
-                    }
-                }
-            });
         }
 
         if let Some(context) = ntcp2_context {

--- a/emissary-core/src/runtime/mod.rs
+++ b/emissary-core/src/runtime/mod.rs
@@ -230,4 +230,7 @@ pub trait AddressBook: Unpin + Send + Sync + 'static {
 pub trait Storage: Unpin + Send + Sync + 'static {
     /// Save routers and their profiles to disk.
     fn save_to_disk(&self, routers: Vec<(String, Option<Vec<u8>>, crate::Profile)>);
+
+    /// Rmoeve routers and their profiles from disk.
+    fn remove_from_disk(&self, routers: Vec<String>);
 }

--- a/emissary-core/src/sam/parser.rs
+++ b/emissary-core/src/sam/parser.rs
@@ -157,8 +157,9 @@ impl fmt::Debug for DestinationContext {
 impl PartialEq for DestinationContext {
     fn eq(&self, other: &Self) -> bool {
         self.destination == other.destination
-            && (*self.private_key).as_ref() == (*other.private_key).as_ref()
-            && (*self.signing_key).as_ref() == (*other.signing_key).as_ref()
+            && AsRef::<[u8]>::as_ref(&self.private_key) == AsRef::<[u8]>::as_ref(&other.private_key)
+            && AsRef::<[u8]>::as_ref(&*self.signing_key)
+                == AsRef::<[u8]>::as_ref(&*other.signing_key)
     }
 }
 

--- a/emissary-core/src/sam/protocol/datagram/mod.rs
+++ b/emissary-core/src/sam/protocol/datagram/mod.rs
@@ -66,7 +66,7 @@ impl<R: Runtime> DatagramManager<R> {
         signing_key: SigningPrivateKey,
     ) -> Self {
         Self {
-            destination_hash: Sha256::new().update(destination.as_ref()).finalize_new(),
+            destination_hash: Sha256::new().update(&*destination).finalize_new(),
             datagram_tx,
             destination,
             listeners: {
@@ -178,7 +178,7 @@ impl<R: Runtime> DatagramManager<R> {
 
                 let info = format!(
                     "{} FROM_PORT={src_port} TO_PORT={dst_port}\n",
-                    base64_encode(destination.as_ref())
+                    base64_encode(&*destination)
                 );
 
                 let info = info.as_bytes();
@@ -241,7 +241,7 @@ impl<R: Runtime> DatagramManager<R> {
 
                 let info = format!(
                     "{} FROM_PORT={src_port} TO_PORT={dst_port}\n",
-                    base64_encode(destination.as_ref())
+                    base64_encode(&*destination)
                 );
 
                 let info = info.as_bytes();

--- a/emissary-core/src/sam/session.rs
+++ b/emissary-core/src/sam/session.rs
@@ -542,7 +542,7 @@ impl<R: Runtime> SamSession<R> {
                     Protocol::Datagram => self.datagram_manager.make_datagram(datagram),
                     Protocol::Datagram2 => self.datagram_manager.make_datagram2(
                         datagram,
-                        &Sha256::new().update(destination.as_ref()).finalize(),
+                        &Sha256::new().update(&*destination).finalize(),
                         options,
                     ),
                     Protocol::Streaming => unreachable!(),
@@ -664,7 +664,7 @@ impl<R: Runtime> SamSession<R> {
                         Protocol::Datagram => self.datagram_manager.make_datagram(datagram),
                         Protocol::Datagram2 => self.datagram_manager.make_datagram2(
                             datagram,
-                            &Sha256::new().update(destination.as_ref()).finalize(),
+                            &Sha256::new().update(&*destination).finalize(),
                             options,
                         ),
                         Protocol::Streaming => unreachable!(),
@@ -1481,7 +1481,7 @@ mod tests {
                 netdb_handle,
                 options,
                 outbound: Default::default(),
-                profile_storage: ProfileStorage::new(&[], &[]),
+                profile_storage: ProfileStorage::new(&[], &[], None),
                 receiver: rx,
                 session_id: "test".into(),
                 session_kind: SessionKind::Stream,

--- a/emissary-core/src/transport/mod.rs
+++ b/emissary-core/src/transport/mod.rs
@@ -1379,6 +1379,7 @@ impl<R: Runtime> Future for TransportManager<R> {
                             Some(false) =>
                                 this.router_ctx.metrics_handle().gauge(NUM_IPV6).decrement(1),
                         }
+                        this.router_ctx.profile_storage().connection_closed(&router_id);
                         this.router_ctx.metrics_handle().gauge(NUM_ACTIVE_CONNECTIONS).decrement(1);
                         this.router_ctx
                             .metrics_handle()
@@ -1667,7 +1668,7 @@ mod tests {
             EventManager::new(None, MockRuntime::register_metrics(vec![], None));
         let ctx = RouterContext::new(
             MockRuntime::register_metrics(vec![], None),
-            ProfileStorage::<MockRuntime>::new(&[], &[]),
+            ProfileStorage::<MockRuntime>::new(&[], &[], None),
             router_info.identity.id(),
             serialized.clone(),
             static_key,
@@ -2247,7 +2248,7 @@ mod tests {
             EventManager::new(None, MockRuntime::register_metrics(vec![], None));
         let ctx = RouterContext::new(
             MockRuntime::register_metrics(vec![], None),
-            ProfileStorage::<MockRuntime>::new(&[], &[]),
+            ProfileStorage::<MockRuntime>::new(&[], &[], None),
             router_info.identity.id(),
             serialized.clone(),
             static_key,
@@ -2365,7 +2366,7 @@ mod tests {
     async fn inbound_connection_rejected_outbound_pending() {
         let (router_info, static_key, signing_key) = RouterInfoBuilder::default().build();
         let serialized = Bytes::from(router_info.serialize(&signing_key));
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         let (_event_mgr, _event_subscriber, event_handle) =
             EventManager::new(None, MockRuntime::register_metrics(vec![], None));
         let (handle, _) = NetDbHandle::create();
@@ -2511,7 +2512,7 @@ mod tests {
     async fn inbound_connection_rejected_while_netdb_lookup_pending() {
         let (router_info, static_key, signing_key) = RouterInfoBuilder::default().build();
         let serialized = Bytes::from(router_info.serialize(&signing_key));
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         let (_event_mgr, _event_subscriber, event_handle) =
             EventManager::new(None, MockRuntime::register_metrics(vec![], None));
         let (handle, netdb_rx) = NetDbHandle::create();
@@ -2653,7 +2654,7 @@ mod tests {
     async fn transit_tunnels_disabled() {
         let (router_info, static_key, signing_key) = RouterInfoBuilder::default().build();
         let serialized = Bytes::from(router_info.serialize(&signing_key));
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         let (handle, _netdb_rx) = NetDbHandle::create();
         let (_event_mgr, _event_subscriber, event_handle) =
             EventManager::new(None, MockRuntime::register_metrics(vec![], None));
@@ -2717,7 +2718,7 @@ mod tests {
     async fn router_info_query_fails() {
         let (router_info, static_key, signing_key) = RouterInfoBuilder::default().build();
         let serialized = Bytes::from(router_info.serialize(&signing_key));
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         let (_event_mgr, _event_subscriber, event_handle) =
             EventManager::new(None, MockRuntime::register_metrics(vec![], None));
         let (handle, netdb_rx) = NetDbHandle::create();
@@ -2828,7 +2829,7 @@ mod tests {
     async fn router_without_ntcp2_support_dialed() {
         let (router_info, static_key, signing_key) = RouterInfoBuilder::default().build();
         let serialized = Bytes::from(router_info.serialize(&signing_key));
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         let (remote_router_info, _, _) = RouterInfoBuilder::default()
             .with_ssu2(Ssu2Config {
                 max_connections: None,
@@ -3003,7 +3004,7 @@ mod tests {
             })
             .build();
         let serialized1 = Bytes::from(router_info1.serialize(&signing_key1));
-        let storage1 = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage1 = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         let router_id1 = router_info1.identity.id();
 
         let config2 = Ssu2Config {
@@ -3044,7 +3045,7 @@ mod tests {
             })
             .build();
         let serialized2 = Bytes::from(router_info2.serialize(&signing_key2));
-        let storage2 = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage2 = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         let router_id2 = router_info2.identity.id();
 
         storage1.add_router(router_info2.clone());
@@ -3219,7 +3220,7 @@ mod tests {
         let (storage, remote_router_id) = {
             let (router_info, _static_key, _signing_key) = RouterInfoBuilder::default().build();
             let router_id = router_info.identity.id();
-            let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+            let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
             storage.add_router(router_info);
 
             (storage, router_id)
@@ -3640,9 +3641,9 @@ mod tests {
             let (router_info, static_key, signing_key) = builder.build();
 
             let profile_storage = if self.routers.is_empty() {
-                ProfileStorage::new(&[], &[])
+                ProfileStorage::new(&[], &[], None)
             } else {
-                let storage = ProfileStorage::new(&[], &[]);
+                let storage = ProfileStorage::new(&[], &[], None);
 
                 for router in self.routers {
                     storage.add_router(router);

--- a/emissary-core/src/transport/ntcp2/session/mod.rs
+++ b/emissary-core/src/transport/ntcp2/session/mod.rs
@@ -950,7 +950,7 @@ mod tests {
             local.ntcp2_iv,
             RouterContext::new(
                 MockRuntime::register_metrics(Vec::new(), None),
-                ProfileStorage::<MockRuntime>::new(&[], &[]),
+                ProfileStorage::<MockRuntime>::new(&[], &[], None),
                 local.router_info.identity.id(),
                 Bytes::from(local.router_info.serialize(&local.signing_key)),
                 local.static_key,
@@ -980,7 +980,7 @@ mod tests {
             remote.ntcp2_iv,
             RouterContext::new(
                 MockRuntime::register_metrics(Vec::new(), None),
-                ProfileStorage::<MockRuntime>::new(&[], &[]),
+                ProfileStorage::<MockRuntime>::new(&[], &[], None),
                 remote.router_info.identity.id(),
                 Bytes::from(remote.router_info.serialize(&remote.signing_key)),
                 remote.static_key,
@@ -1043,7 +1043,7 @@ mod tests {
             local.ntcp2_iv,
             RouterContext::new(
                 MockRuntime::register_metrics(Vec::new(), None),
-                ProfileStorage::<MockRuntime>::new(&[], &[]),
+                ProfileStorage::<MockRuntime>::new(&[], &[], None),
                 local.router_info.identity.id(),
                 Bytes::from(local.router_info.serialize(&local.signing_key)),
                 local.static_key,
@@ -1073,7 +1073,7 @@ mod tests {
             remote.ntcp2_iv,
             RouterContext::new(
                 MockRuntime::register_metrics(Vec::new(), None),
-                ProfileStorage::<MockRuntime>::new(&[], &[]),
+                ProfileStorage::<MockRuntime>::new(&[], &[], None),
                 remote.router_info.identity.id(),
                 Bytes::from(remote.router_info.serialize(&remote.signing_key)),
                 remote.static_key,
@@ -1134,7 +1134,7 @@ mod tests {
             local.ntcp2_iv,
             RouterContext::new(
                 MockRuntime::register_metrics(Vec::new(), None),
-                ProfileStorage::<MockRuntime>::new(&[], &[]),
+                ProfileStorage::<MockRuntime>::new(&[], &[], None),
                 local.router_info.identity.id(),
                 Bytes::from(local.router_info.serialize(&local.signing_key)),
                 local.static_key,
@@ -1165,7 +1165,7 @@ mod tests {
             remote.ntcp2_iv,
             RouterContext::new(
                 MockRuntime::register_metrics(Vec::new(), None),
-                ProfileStorage::<MockRuntime>::new(&[], &[]),
+                ProfileStorage::<MockRuntime>::new(&[], &[], None),
                 remote.router_info.identity.id(),
                 Bytes::from(remote.router_info.serialize(&remote.signing_key)),
                 remote.static_key,
@@ -1201,7 +1201,7 @@ mod tests {
             local.ntcp2_iv,
             RouterContext::new(
                 MockRuntime::register_metrics(Vec::new(), None),
-                ProfileStorage::<MockRuntime>::new(&[], &[]),
+                ProfileStorage::<MockRuntime>::new(&[], &[], None),
                 local.router_info.identity.id(),
                 Bytes::from(local.router_info.serialize(&local.signing_key)),
                 local.static_key,
@@ -1225,7 +1225,7 @@ mod tests {
             remote.ntcp2_iv,
             RouterContext::new(
                 MockRuntime::register_metrics(Vec::new(), None),
-                ProfileStorage::<MockRuntime>::new(&[], &[]),
+                ProfileStorage::<MockRuntime>::new(&[], &[], None),
                 remote.router_info.identity.id(),
                 Bytes::from(remote.router_info.serialize(&remote.signing_key)),
                 remote.static_key,
@@ -1260,7 +1260,7 @@ mod tests {
             local.ntcp2_iv,
             RouterContext::new(
                 MockRuntime::register_metrics(Vec::new(), None),
-                ProfileStorage::<MockRuntime>::new(&[], &[]),
+                ProfileStorage::<MockRuntime>::new(&[], &[], None),
                 local.router_info.identity.id(),
                 Bytes::from(local.router_info.serialize(&local.signing_key)),
                 local.static_key,
@@ -1324,7 +1324,7 @@ mod tests {
             local.ntcp2_iv,
             RouterContext::new(
                 MockRuntime::register_metrics(Vec::new(), None),
-                ProfileStorage::<MockRuntime>::new(&[], &[]),
+                ProfileStorage::<MockRuntime>::new(&[], &[], None),
                 local.router_info.identity.id(),
                 Bytes::from(local.router_info.serialize(&local.signing_key)),
                 local.static_key,
@@ -1355,7 +1355,7 @@ mod tests {
             remote.ntcp2_iv,
             RouterContext::new(
                 MockRuntime::register_metrics(Vec::new(), None),
-                ProfileStorage::<MockRuntime>::new(&[], &[]),
+                ProfileStorage::<MockRuntime>::new(&[], &[], None),
                 remote.router_info.identity.id(),
                 Bytes::from(remote.router_info.serialize(&remote.signing_key)),
                 remote.static_key,
@@ -1517,7 +1517,7 @@ mod tests {
             remote.ntcp2_iv,
             RouterContext::new(
                 MockRuntime::register_metrics(Vec::new(), None),
-                ProfileStorage::<MockRuntime>::new(&[], &[]),
+                ProfileStorage::<MockRuntime>::new(&[], &[], None),
                 remote.router_info.identity.id(),
                 Bytes::from(remote.router_info.serialize(&remote.signing_key)),
                 remote.static_key,
@@ -1553,7 +1553,7 @@ mod tests {
                     local.ntcp2_iv,
                     RouterContext::new(
                         MockRuntime::register_metrics(Vec::new(), None),
-                        ProfileStorage::<MockRuntime>::new(&[], &[]),
+                        ProfileStorage::<MockRuntime>::new(&[], &[], None),
                         local.router_info.identity.id(),
                         Bytes::from(local.router_info.serialize(&local.signing_key)),
                         local.static_key,
@@ -1620,7 +1620,7 @@ mod tests {
             remote.ntcp2_iv,
             RouterContext::new(
                 MockRuntime::register_metrics(Vec::new(), None),
-                ProfileStorage::<MockRuntime>::new(&[], &[]),
+                ProfileStorage::<MockRuntime>::new(&[], &[], None),
                 remote.router_info.identity.id(),
                 Bytes::from(remote.router_info.serialize(&remote.signing_key)),
                 remote.static_key,
@@ -1656,7 +1656,7 @@ mod tests {
                     local.ntcp2_iv,
                     RouterContext::new(
                         MockRuntime::register_metrics(Vec::new(), None),
-                        ProfileStorage::<MockRuntime>::new(&[], &[]),
+                        ProfileStorage::<MockRuntime>::new(&[], &[], None),
                         local.router_info.identity.id(),
                         Bytes::from(local.router_info.serialize(&local.signing_key)),
                         local.static_key,
@@ -1694,7 +1694,7 @@ mod tests {
             local.ntcp2_iv,
             RouterContext::new(
                 MockRuntime::register_metrics(Vec::new(), None),
-                ProfileStorage::<MockRuntime>::new(&[], &[]),
+                ProfileStorage::<MockRuntime>::new(&[], &[], None),
                 local.router_info.identity.id(),
                 Bytes::from(local.router_info.serialize(&local.signing_key)),
                 local.static_key,
@@ -1717,7 +1717,7 @@ mod tests {
             remote.ntcp2_iv,
             RouterContext::new(
                 MockRuntime::register_metrics(Vec::new(), None),
-                ProfileStorage::<MockRuntime>::new(&[], &[]),
+                ProfileStorage::<MockRuntime>::new(&[], &[], None),
                 remote.router_info.identity.id(),
                 Bytes::from(remote.router_info.serialize(&remote.signing_key)),
                 remote.static_key,

--- a/emissary-core/src/transport/ssu2/mod.rs
+++ b/emissary-core/src/transport/ssu2/mod.rs
@@ -541,7 +541,7 @@ mod tests {
             true,
             RouterContext::new(
                 MockRuntime::register_metrics(Vec::new(), None),
-                ProfileStorage::<MockRuntime>::new(&[], &[]),
+                ProfileStorage::<MockRuntime>::new(&[], &[], None),
                 router_info1.identity.id(),
                 Bytes::from(router_info1.serialize(&signing1)),
                 static1,
@@ -556,7 +556,7 @@ mod tests {
             true,
             RouterContext::new(
                 MockRuntime::register_metrics(Vec::new(), None),
-                ProfileStorage::<MockRuntime>::new(&[], &[]),
+                ProfileStorage::<MockRuntime>::new(&[], &[], None),
                 router_info2.identity.id(),
                 Bytes::from(router_info2.serialize(&signing2)),
                 static2,
@@ -723,7 +723,7 @@ mod tests {
             true,
             RouterContext::new(
                 MockRuntime::register_metrics(Vec::new(), None),
-                ProfileStorage::<MockRuntime>::new(&[], &[]),
+                ProfileStorage::<MockRuntime>::new(&[], &[], None),
                 router_info1.identity.id(),
                 Bytes::from(router_info1.serialize(&signing1)),
                 static1,
@@ -738,7 +738,7 @@ mod tests {
             true,
             RouterContext::new(
                 MockRuntime::register_metrics(Vec::new(), None),
-                ProfileStorage::<MockRuntime>::new(&[], &[]),
+                ProfileStorage::<MockRuntime>::new(&[], &[], None),
                 router_info2.identity.id(),
                 Bytes::from(router_info2.serialize(&signing2)),
                 static2,
@@ -908,21 +908,21 @@ mod tests {
         let serialized3 = Bytes::from(router_info3.serialize(&signing3));
 
         let storage1 = {
-            let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+            let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
             storage.discover_router(router_info2.clone(), serialized2.clone());
             storage.discover_router(router_info3.clone(), serialized3.clone());
 
             storage
         };
         let storage2 = {
-            let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+            let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
             storage.discover_router(router_info3.clone(), serialized3.clone());
             storage.discover_router(router_info1.clone(), serialized1.clone());
 
             storage
         };
         let storage3 = {
-            let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+            let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
             storage.discover_router(router_info2.clone(), serialized2.clone());
             storage.discover_router(router_info1.clone(), serialized1.clone());
 
@@ -1195,7 +1195,7 @@ mod tests {
         let (event1_tx, event1_rx) = channel(64);
         let (event2_tx, _event2_rx) = channel(64);
 
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         storage.add_router(router_info2.clone());
         let mut transport1 = Ssu2Transport::<MockRuntime>::new(
             ctx1,
@@ -1217,7 +1217,7 @@ mod tests {
             true,
             RouterContext::new(
                 MockRuntime::register_metrics(Vec::new(), None),
-                ProfileStorage::<MockRuntime>::new(&[], &[]),
+                ProfileStorage::<MockRuntime>::new(&[], &[], None),
                 router_info2.identity.id(),
                 Bytes::from(router_info2.serialize(&signing2)),
                 static2,
@@ -1370,7 +1370,7 @@ mod tests {
             false,
         );
         let (event3_tx, event3_rx) = channel(64);
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         storage.add_router(router_info2.clone());
 
         let mut transport3 = Ssu2Transport::<MockRuntime>::new(
@@ -1599,7 +1599,7 @@ mod tests {
             true,
             RouterContext::new(
                 MockRuntime::register_metrics(Vec::new(), None),
-                ProfileStorage::<MockRuntime>::new(&[], &[]),
+                ProfileStorage::<MockRuntime>::new(&[], &[], None),
                 router_info1.identity.id(),
                 Bytes::from(router_info1.serialize(&signing1)),
                 static1,
@@ -1614,7 +1614,7 @@ mod tests {
             true,
             RouterContext::new(
                 MockRuntime::register_metrics(Vec::new(), None),
-                ProfileStorage::<MockRuntime>::new(&[], &[]),
+                ProfileStorage::<MockRuntime>::new(&[], &[], None),
                 router_info2.identity.id(),
                 Bytes::from(router_info2.serialize(&signing2)),
                 static2,
@@ -1866,7 +1866,7 @@ mod tests {
             true,
             RouterContext::new(
                 MockRuntime::register_metrics(Vec::new(), None),
-                ProfileStorage::<MockRuntime>::new(&[], &[]),
+                ProfileStorage::<MockRuntime>::new(&[], &[], None),
                 router_info1.identity.id(),
                 Bytes::from(router_info1.serialize(&signing1)),
                 static1,
@@ -1881,7 +1881,7 @@ mod tests {
             true,
             RouterContext::new(
                 MockRuntime::register_metrics(Vec::new(), None),
-                ProfileStorage::<MockRuntime>::new(&[], &[]),
+                ProfileStorage::<MockRuntime>::new(&[], &[], None),
                 router_info2.identity.id(),
                 Bytes::from(router_info2.serialize(&signing2)),
                 static2,
@@ -1896,7 +1896,7 @@ mod tests {
             true,
             RouterContext::new(
                 MockRuntime::register_metrics(Vec::new(), None),
-                ProfileStorage::<MockRuntime>::new(&[], &[]),
+                ProfileStorage::<MockRuntime>::new(&[], &[], None),
                 router_info3.identity.id(),
                 Bytes::from(router_info3.serialize(&signing3)),
                 static3,

--- a/emissary-core/src/transport/ssu2/peer_test/mod.rs
+++ b/emissary-core/src/transport/ssu2/peer_test/mod.rs
@@ -1576,7 +1576,7 @@ mod tests {
     async fn session_doesnt_support_ssu2() {
         let (router_info, _, _) = RouterInfoBuilder::default().build();
         let router_id = router_info.identity.id();
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         storage.add_router(router_info);
 
         let mut manager = PeerTestManager::new(
@@ -1599,7 +1599,7 @@ mod tests {
     #[tokio::test]
     async fn router_doesnt_support_peer_testing() {
         let (router_id, router_info, _) = make_router_info(Str::from("C"), Some(true));
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         storage.add_router(router_info);
 
         let mut manager = PeerTestManager::new(
@@ -1622,7 +1622,7 @@ mod tests {
     #[tokio::test]
     async fn router_doesnt_support_ipv4_or_ipv6() {
         let (router_id, router_info, _) = make_router_info(Str::from("BC"), None);
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         storage.add_router(router_info);
 
         let mut manager = PeerTestManager::new(
@@ -1645,7 +1645,7 @@ mod tests {
     #[tokio::test]
     async fn router_supports_peer_testing_over_ipv4() {
         let (router_id, router_info, _) = make_router_info(Str::from("BC"), Some(true));
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         storage.add_router(router_info);
 
         let mut manager = PeerTestManager::new(
@@ -1669,7 +1669,7 @@ mod tests {
     #[tokio::test]
     async fn router_supports_peer_testing_over_ipv6() {
         let (router_id, router_info, _) = make_router_info(Str::from("BC"), Some(false));
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         storage.add_router(router_info);
 
         let mut manager = PeerTestManager::new(
@@ -1693,7 +1693,7 @@ mod tests {
     #[tokio::test]
     #[should_panic]
     async fn inbound_request_alice_doesnt_exist() {
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         let (router_id, router_info, _) = make_router_info(Str::from("BC"), Some(true));
         storage.add_router(router_info);
 
@@ -1727,7 +1727,7 @@ mod tests {
     // make sure it's not chosen as charlie
     #[tokio::test]
     async fn inbound_request_alice_is_not_chosen() {
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         let (router_id, router_info, _) = make_router_info(Str::from("BC"), Some(true));
         storage.add_router(router_info);
 
@@ -1766,7 +1766,7 @@ mod tests {
 
     #[tokio::test]
     async fn inbound_request_rejected_no_ipv4_routers() {
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         let (router_id1, router_info1, _) = make_router_info(Str::from("BC"), Some(true));
         let (_router_id2, router_info2, _) = make_router_info(Str::from("BC"), Some(false));
         storage.add_router(router_info1);
@@ -1807,7 +1807,7 @@ mod tests {
 
     #[tokio::test]
     async fn inbound_request_rejected_no_ipv6_routers() {
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         let (router_id1, router_info1, _) = make_router_info(Str::from("BC"), Some(false));
         let (_router_id2, router_info2, _) = make_router_info(Str::from("BC"), Some(true));
         storage.add_router(router_info1);
@@ -1848,7 +1848,7 @@ mod tests {
 
     #[tokio::test]
     async fn inbound_request_accepted() {
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         let (router_id1, router_info1, serialized1) = make_router_info(Str::from("BC"), Some(true));
         let (router_id2, router_info2, serialized2) = make_router_info(Str::from("BC"), Some(true));
         storage.discover_router(router_info1, serialized1);
@@ -1911,7 +1911,7 @@ mod tests {
 
     #[tokio::test]
     async fn bob_request_rejected_already_connected() {
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         let (alice_router_id, alice_router_info, alice_serialized) =
             make_router_info(Str::from("BC"), Some(true));
         let (bob_router_id, bob_router_info, bob_serialized) =
@@ -1965,7 +1965,7 @@ mod tests {
 
     #[tokio::test]
     async fn bob_request_rejected_ipv6_not_supported() {
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         let (alice_router_id, alice_router_info, alice_serialized) =
             make_router_info(Str::from("BC"), Some(true));
         let (bob_router_id, bob_router_info, bob_serialized) =
@@ -2017,7 +2017,7 @@ mod tests {
 
     #[tokio::test]
     async fn bob_request_rejected_ipv4_not_supported() {
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         let (alice_router_id, alice_router_info, alice_serialized) =
             make_router_info(Str::from("BC"), Some(true));
         let (bob_router_id, bob_router_info, bob_serialized) =
@@ -2069,7 +2069,7 @@ mod tests {
 
     #[tokio::test]
     async fn bob_request_accepted() {
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         let (alice_router_id, alice_router_info, alice_serialized) =
             make_router_info(Str::from("BC"), Some(true));
         let (bob_router_id, bob_router_info, bob_serialized) =
@@ -2166,7 +2166,7 @@ mod tests {
 
     #[tokio::test]
     async fn alice_request_charlie_no_longer_connected() {
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         let (charlie_router_id, charlie_router_info, charlie_serialized) =
             make_router_info(Str::from("BC"), Some(true));
         let (alice_router_id, alice_router_info, alice_serialized) =
@@ -2232,7 +2232,7 @@ mod tests {
 
     #[tokio::test]
     async fn charlie_response_relayed() {
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         let (charlie_router_id, charlie_router_info, charlie_serialized) =
             make_router_info(Str::from("BC"), Some(true));
         let (alice_router_id, alice_router_info, alice_serialized) =
@@ -2616,7 +2616,7 @@ mod tests {
         let charlie_router_id = charlie_router_info.identity.id();
 
         // add bob to alice's router storage so they can be contacted
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         storage.discover_router(bob_router_info, Bytes::from(bob_serialized));
 
         // create alice
@@ -2800,7 +2800,7 @@ mod tests {
         let charlie_address = charlie_socket.local_address().unwrap();
 
         // add bob to alice's router storage so they can be contacted
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         storage.discover_router(bob_router_info, Bytes::from(bob_serialized));
 
         // create alice
@@ -2963,7 +2963,7 @@ mod tests {
         let charlie_router_id = charlie_router_info.identity.id();
 
         // add bob to alice's router storage so they can be contacted
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         storage.discover_router(bob_router_info, Bytes::from(bob_serialized));
 
         // create alice
@@ -3181,7 +3181,7 @@ mod tests {
         let charlie_router_id = charlie_router_info.identity.id();
 
         // add bob to alice's router storage so they can be contacted
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         storage.discover_router(bob_router_info, Bytes::from(bob_serialized));
 
         // create alice
@@ -3370,7 +3370,7 @@ mod tests {
         let charlie_router_id = charlie_router_info.identity.id();
 
         // add bob to alice's router storage so they can be contacted
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         storage.discover_router(bob_router_info, Bytes::from(bob_serialized));
 
         // create alice
@@ -3554,7 +3554,7 @@ mod tests {
         let bob_router_id = bob_router_info.identity.id();
 
         // add bob to alice's router storage so they can be contacted
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         storage.discover_router(bob_router_info, Bytes::from(bob_serialized));
 
         // create alice
@@ -3612,7 +3612,7 @@ mod tests {
     #[tokio::test]
     async fn parallel_tests() {
         // create 10 routers which all support peer testing
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         let mut channels = Vec::new();
         let mut routers = Vec::new();
 
@@ -3677,7 +3677,7 @@ mod tests {
     #[tokio::test]
     async fn parallel_test_not_enough_routers() {
         // add only 3 routers (3 < MAX_PARALLEL_TESTS)
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         let mut channels = Vec::new();
         let mut routers = Vec::new();
 
@@ -3742,7 +3742,7 @@ mod tests {
     #[tokio::test]
     async fn pending_test_no_new_tests_started() {
         // create 10 routers which all support peer testing
-        let storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         let mut channels = Vec::new();
         let mut routers = Vec::new();
 

--- a/emissary-core/src/transport/ssu2/relay/mod.rs
+++ b/emissary-core/src/transport/ssu2/relay/mod.rs
@@ -1464,7 +1464,7 @@ mod tests {
                     bob.signing_key.clone(),
                 )
                 .with_profile_storage({
-                    let storage = ProfileStorage::new(&[], &[]);
+                    let storage = ProfileStorage::new(&[], &[], None);
                     storage.discover_router(
                         alice.router_info.clone(),
                         Bytes::from(alice.serialized.clone()),
@@ -1556,7 +1556,7 @@ mod tests {
                     bob.signing_key.clone(),
                 )
                 .with_profile_storage({
-                    let storage = ProfileStorage::new(&[], &[]);
+                    let storage = ProfileStorage::new(&[], &[], None);
                     storage.discover_router(
                         alice.router_info.clone(),
                         Bytes::from(alice.serialized.clone()),
@@ -1757,7 +1757,7 @@ mod tests {
             [0xab; 32],
             RouterContextBuilder::default()
                 .with_profile_storage({
-                    let storage = ProfileStorage::new(&[], &[]);
+                    let storage = ProfileStorage::new(&[], &[], None);
                     storage.discover_router(
                         alice.router_info.clone(),
                         Bytes::from(alice.serialized.clone()),
@@ -1871,7 +1871,7 @@ mod tests {
                     charlie.signing_key.clone(),
                 )
                 .with_profile_storage({
-                    let storage = ProfileStorage::new(&[], &[]);
+                    let storage = ProfileStorage::new(&[], &[], None);
                     storage.discover_router(
                         alice.router_info.clone(),
                         Bytes::from(alice.serialized.clone()),

--- a/emissary-core/src/transport/ssu2/session/active/mod.rs
+++ b/emissary-core/src/transport/ssu2/session/active/mod.rs
@@ -871,7 +871,7 @@ mod tests {
             EventManager::new(None, MockRuntime::register_metrics(vec![], None));
         let router_ctx = RouterContext::new(
             MockRuntime::register_metrics(vec![], None),
-            ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new()),
+            ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None),
             router_info.identity.id(),
             Bytes::from(router_info.serialize(&signing_key)),
             static_key.clone(),

--- a/emissary-core/src/transport/ssu2/session/active/peer_test.rs
+++ b/emissary-core/src/transport/ssu2/session/active/peer_test.rs
@@ -567,7 +567,7 @@ mod tests {
             EventManager::new(None, MockRuntime::register_metrics(vec![], None));
         let router_ctx = RouterContext::new(
             MockRuntime::register_metrics(vec![], None),
-            ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new()),
+            ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None),
             router_info.identity.id(),
             Bytes::from(router_info.serialize(&signing_key)),
             static_key.clone(),

--- a/emissary-core/src/tunnel/hop/pending.rs
+++ b/emissary-core/src/tunnel/hop/pending.rs
@@ -845,7 +845,7 @@ mod test {
                                 }),
                                 RouterContext::new(
                                     handle.clone(),
-                                    ProfileStorage::new(&[], &[]),
+                                    ProfileStorage::new(&[], &[], None),
                                     router_info.identity.id(),
                                     Bytes::from(router_info.serialize(&signing_key)),
                                     static_key,
@@ -1255,7 +1255,7 @@ mod test {
                 }),
                 RouterContext::new(
                     handle.clone(),
-                    ProfileStorage::new(&[], &[]),
+                    ProfileStorage::new(&[], &[], None),
                     router_info.identity.id(),
                     Bytes::from(router_info.serialize(&signing_key)),
                     static_key,
@@ -1506,7 +1506,7 @@ mod test {
                                 }),
                                 RouterContext::new(
                                     handle.clone(),
-                                    ProfileStorage::new(&[], &[]),
+                                    ProfileStorage::new(&[], &[], None),
                                     router_info.identity.id(),
                                     Bytes::from(router_info.serialize(&signing_key)),
                                     static_key,
@@ -1658,7 +1658,7 @@ mod test {
                                 }),
                                 RouterContext::new(
                                     handle.clone(),
-                                    ProfileStorage::new(&[], &[]),
+                                    ProfileStorage::new(&[], &[], None),
                                     router_info.identity.id(),
                                     Bytes::from(router_info.serialize(&signing_key)),
                                     static_key,
@@ -1774,7 +1774,7 @@ mod test {
                                 }),
                                 RouterContext::new(
                                     handle.clone(),
-                                    ProfileStorage::new(&[], &[]),
+                                    ProfileStorage::new(&[], &[], None),
                                     router_info.identity.id(),
                                     Bytes::from(router_info.serialize(&signing_key)),
                                     static_key,
@@ -1890,7 +1890,7 @@ mod test {
                                 }),
                                 RouterContext::new(
                                     handle.clone(),
-                                    ProfileStorage::new(&[], &[]),
+                                    ProfileStorage::new(&[], &[], None),
                                     router_info.identity.id(),
                                     Bytes::from(router_info.serialize(&signing_key)),
                                     static_key,

--- a/emissary-core/src/tunnel/pool/listener.rs
+++ b/emissary-core/src/tunnel/pool/listener.rs
@@ -234,7 +234,7 @@ mod tests {
 
     #[tokio::test]
     async fn response_channel_closed() {
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         let (hops, _noise_contexts): (Vec<(Bytes, StaticPublicKey)>, Vec<NoiseContext>) = (0..3)
             .map(|i| make_router(if i % 2 == 0 { true } else { false }))
             .into_iter()
@@ -286,7 +286,7 @@ mod tests {
 
     #[tokio::test]
     async fn tunnel_build_timeouts() {
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         let (hops, _noise_contexts): (Vec<(Bytes, StaticPublicKey)>, Vec<NoiseContext>) = (0..3)
             .map(|i| make_router(if i % 2 == 0 { true } else { false }))
             .into_iter()
@@ -338,7 +338,7 @@ mod tests {
 
     #[tokio::test]
     async fn tunnel_build_dial_failure() {
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&[], &[]);
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&[], &[], None);
         let (hops, _noise_contexts): (Vec<(Bytes, StaticPublicKey)>, Vec<NoiseContext>) = (0..3)
             .map(|i| make_router(if i % 2 == 0 { true } else { false }))
             .into_iter()

--- a/emissary-core/src/tunnel/pool/selector.rs
+++ b/emissary-core/src/tunnel/pool/selector.rs
@@ -1076,7 +1076,7 @@ mod tests {
     #[tokio::test]
     async fn not_enough_routers_for_exploratory_tunnel() {
         let build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         for _ in 0..3 {
             profile_storage.add_router({
@@ -1097,7 +1097,7 @@ mod tests {
     #[tokio::test]
     async fn select_exploratory_hops() {
         let build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         for _ in 0..10 {
             profile_storage.add_router({
@@ -1134,7 +1134,7 @@ mod tests {
     #[tokio::test]
     async fn select_exploratory_hops_ipv6() {
         let build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         for _ in 0..10 {
             profile_storage.add_router({
@@ -1171,7 +1171,7 @@ mod tests {
     #[tokio::test]
     async fn select_exploratory_hops_mixed() {
         let build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         for _ in 0..10 {
             profile_storage.add_router({
@@ -1208,7 +1208,7 @@ mod tests {
     #[tokio::test]
     async fn use_fast_routers_as_fallback() {
         let build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         for i in 0..3 {
             profile_storage.add_router({
@@ -1276,7 +1276,7 @@ mod tests {
     async fn not_enough_routers_for_client_tunnel() {
         let exploratory_build_parameters = TunnelPoolBuildParameters::new(Default::default());
         let client_build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         for _ in 0..3 {
             profile_storage.add_router({
@@ -1300,7 +1300,7 @@ mod tests {
     async fn select_client_hops() {
         let exploratory_build_parameters = TunnelPoolBuildParameters::new(Default::default());
         let client_build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         for _ in 0..10 {
             profile_storage.add_router({
@@ -1340,7 +1340,7 @@ mod tests {
     async fn use_standard_routers_as_fallback() {
         let exploratory_build_parameters = TunnelPoolBuildParameters::new(Default::default());
         let client_build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         for _ in 0..5 {
             profile_storage.add_router({
@@ -1389,7 +1389,7 @@ mod tests {
     #[tokio::test]
     async fn exploratory_not_enough_routers_in_distinct_subnets() {
         let build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         // 5 addresses from 192.168.x.x subnet
         for i in 0..5 {
@@ -1442,7 +1442,7 @@ mod tests {
     #[tokio::test]
     async fn exploratory_not_enough_routers_in_distinct_subnets_ipv6() {
         let build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         let first_subnet: Vec<Ipv6Addr> = vec![
             "2001:db8:abcd:0001::1".parse().unwrap(),
@@ -1508,7 +1508,7 @@ mod tests {
     async fn client_not_enough_routers_in_distinct_subnets() {
         let exploratory_build_parameters = TunnelPoolBuildParameters::new(Default::default());
         let client_build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         // 5 addresses from 192.168.x.x subnet
         for i in 0..5 {
@@ -1565,7 +1565,7 @@ mod tests {
     async fn client_not_enough_routers_in_distinct_subnets_ipv4() {
         let exploratory_build_parameters = TunnelPoolBuildParameters::new(Default::default());
         let client_build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         let first_subnet: Vec<Ipv6Addr> = vec![
             "2001:db8:abcd:0001::1".parse().unwrap(),
@@ -1632,7 +1632,7 @@ mod tests {
     #[tokio::test]
     async fn exploratory_not_enough_reachable_routers() {
         let build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         // 5 unreachable standard routers
         for i in 0..5 {
@@ -1670,7 +1670,7 @@ mod tests {
     async fn client_not_enough_standard_or_fast_routers() {
         let exploratory_build_parameters = TunnelPoolBuildParameters::new(Default::default());
         let client_build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         // 3 reachable standard routers
         for _ in 0..3 {
@@ -1709,7 +1709,7 @@ mod tests {
     #[tokio::test]
     async fn exploratory_insecure_tunnels_not_enough_distinct_subnets() {
         let build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         // 5 addresses from 192.168.x.x subnet
         for i in 0..5 {
@@ -1767,7 +1767,7 @@ mod tests {
     #[tokio::test]
     async fn exploratory_insecure_tunnels_not_enough_distinct_subnets_ipv6() {
         let build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         let first_subnet: Vec<Ipv6Addr> = vec![
             "2001:db8:abcd:0001::1".parse().unwrap(),
@@ -1837,7 +1837,7 @@ mod tests {
     async fn client_insecure_tunnels_not_enough_distinct_subnets() {
         let exploratory_build_parameters = TunnelPoolBuildParameters::new(Default::default());
         let client_build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         // 5 addresses from 192.168.x.x subnet
         for i in 0..5 {
@@ -1898,7 +1898,7 @@ mod tests {
     async fn client_insecure_tunnels_not_enough_distinct_subnets_ipv6() {
         let exploratory_build_parameters = TunnelPoolBuildParameters::new(Default::default());
         let client_build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         let first_subnet: Vec<Ipv6Addr> = vec![
             "2001:db8:abcd:0001::1".parse().unwrap(),
@@ -1969,7 +1969,7 @@ mod tests {
     #[tokio::test]
     async fn exploratory_insecure_tunnels_not_enough_distinct_subnets_or_standard_peers() {
         let build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         // 5 addresses from 192.168.x.x subnet
         for i in 0..3 {
@@ -2051,7 +2051,7 @@ mod tests {
     #[tokio::test]
     async fn exploratory_insecure_tunnels_not_enough_distinct_subnets_or_standard_peers_ipv6() {
         let build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         let first_subnet: Vec<Ipv6Addr> = vec![
             "2001:db8:abcd:0001::1".parse().unwrap(),
@@ -2143,7 +2143,7 @@ mod tests {
     async fn client_insecure_tunnels_not_enough_distinct_subnets_or_fast_peers() {
         let exploratory_build_parameters = TunnelPoolBuildParameters::new(Default::default());
         let client_build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         // 5 addresses from 192.168.x.x subnet
         for i in 0..5 {
@@ -2228,7 +2228,7 @@ mod tests {
     async fn client_insecure_tunnels_not_enough_distinct_subnets_or_fast_peers_ipv6() {
         let exploratory_build_parameters = TunnelPoolBuildParameters::new(Default::default());
         let client_build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         let first_subnet: Vec<Ipv6Addr> = vec![
             "2001:db8:abcd:0001::1".parse().unwrap(),
@@ -2321,7 +2321,7 @@ mod tests {
     #[tokio::test]
     async fn router_participation() {
         let build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
         let routers = (0..11).map(|_| RouterId::random()).collect::<Vec<_>>();
 
         let selector = ExploratorySelector::new(
@@ -2400,7 +2400,7 @@ mod tests {
     #[tokio::test]
     async fn exploratory_enforce_max_participation() {
         let build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         for _ in 0..6 {
             profile_storage.add_router({
@@ -2439,7 +2439,7 @@ mod tests {
     #[tokio::test]
     async fn exploratory_ignore_max_participation_for_insecure_tunnels() {
         let build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         for _ in 0..6 {
             profile_storage.add_router({
@@ -2477,7 +2477,7 @@ mod tests {
     #[tokio::test]
     async fn exploratory_enforce_max_participation_with_fast_fallbacks() {
         let build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         for _ in 0..6 {
             profile_storage.add_router({
@@ -2552,7 +2552,7 @@ mod tests {
     async fn client_enforce_max_participation() {
         let exploratory_build_parameters = TunnelPoolBuildParameters::new(Default::default());
         let client_build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         for _ in 0..6 {
             profile_storage.add_router({
@@ -2594,7 +2594,7 @@ mod tests {
     async fn client_ignore_max_participation_for_insecure_tunnels() {
         let exploratory_build_parameters = TunnelPoolBuildParameters::new(Default::default());
         let client_build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         for _ in 0..6 {
             profile_storage.add_router({
@@ -2635,7 +2635,7 @@ mod tests {
     async fn client_enforce_max_participation_with_fast_fallbacks() {
         let exploratory_build_parameters = TunnelPoolBuildParameters::new(Default::default());
         let client_build_parameters = TunnelPoolBuildParameters::new(Default::default());
-        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new());
+        let profile_storage = ProfileStorage::<MockRuntime>::new(&Vec::new(), &Vec::new(), None);
 
         for _ in 0..3 {
             profile_storage.add_router({

--- a/emissary-core/src/tunnel/tests/mod.rs
+++ b/emissary-core/src/tunnel/tests/mod.rs
@@ -168,7 +168,7 @@ impl TestTransitTunnelManager {
                 }),
                 RouterContext::new(
                     MockRuntime::register_metrics(vec![], None),
-                    ProfileStorage::new(&[], &[]),
+                    ProfileStorage::new(&[], &[], None),
                     router_info.identity.id(),
                     Bytes::from(router_info.serialize(&signing_key)),
                     static_key,

--- a/emissary-core/src/tunnel/transit/mod.rs
+++ b/emissary-core/src/tunnel/transit/mod.rs
@@ -996,7 +996,7 @@ mod tests {
                             }),
                             RouterContext::new(
                                 handle.clone(),
-                                ProfileStorage::new(&[], &[]),
+                                ProfileStorage::new(&[], &[], None),
                                 router_info.identity.id(),
                                 Bytes::from(router_info.serialize(&signing_key)),
                                 static_key,
@@ -1072,7 +1072,7 @@ mod tests {
                                 }),
                                 RouterContext::new(
                                     handle.clone(),
-                                    ProfileStorage::new(&[], &[]),
+                                    ProfileStorage::new(&[], &[], None),
                                     router_info.identity.id(),
                                     Bytes::from(router_info.serialize(&signing_key)),
                                     static_key,
@@ -1155,7 +1155,7 @@ mod tests {
                             }),
                             RouterContext::new(
                                 handle.clone(),
-                                ProfileStorage::new(&[], &[]),
+                                ProfileStorage::new(&[], &[], None),
                                 router_info.identity.id(),
                                 Bytes::from(router_info.serialize(&signing_key)),
                                 static_key,
@@ -1249,7 +1249,7 @@ mod tests {
                             }),
                             RouterContext::new(
                                 handle.clone(),
-                                ProfileStorage::new(&[], &[]),
+                                ProfileStorage::new(&[], &[], None),
                                 router_info.identity.id(),
                                 Bytes::from(router_info.serialize(&signing_key)),
                                 static_key,
@@ -1303,7 +1303,7 @@ mod tests {
             None,
             RouterContext::new(
                 handle.clone(),
-                ProfileStorage::new(&[], &[]),
+                ProfileStorage::new(&[], &[], None),
                 router_info.identity.id(),
                 Bytes::from(router_info.serialize(&signing_key)),
                 static_key,
@@ -1347,7 +1347,7 @@ mod tests {
                         }),
                         RouterContext::new(
                             handle.clone(),
-                            ProfileStorage::new(&[], &[]),
+                            ProfileStorage::new(&[], &[], None),
                             router_info.identity.id(),
                             Bytes::from(router_info.serialize(&signing_key)),
                             static_key,
@@ -1437,7 +1437,7 @@ mod tests {
                 }),
                 RouterContext::new(
                     handle.clone(),
-                    ProfileStorage::new(&[], &[]),
+                    ProfileStorage::new(&[], &[], None),
                     router_info.identity.id(),
                     Bytes::from(router_info.serialize(&signing_key)),
                     static_key,
@@ -1521,7 +1521,7 @@ mod tests {
             None,
             RouterContext::new(
                 handle.clone(),
-                ProfileStorage::new(&[], &[]),
+                ProfileStorage::new(&[], &[], None),
                 router_info.identity.id(),
                 Bytes::from(router_info.serialize(&signing_key)),
                 static_key,
@@ -1584,7 +1584,7 @@ mod tests {
                 },
                 RouterContext::new(
                     handle.clone(),
-                    ProfileStorage::new(&[], &[]),
+                    ProfileStorage::new(&[], &[], None),
                     router_info.identity.id(),
                     Bytes::from(router_info.serialize(&signing_key)),
                     static_key,
@@ -1684,7 +1684,7 @@ mod tests {
                 },
                 RouterContext::new(
                     handle.clone(),
-                    ProfileStorage::new(&[], &[]),
+                    ProfileStorage::new(&[], &[], None),
                     router_info.identity.id(),
                     Bytes::from(router_info.serialize(&signing_key)),
                     static_key,
@@ -1783,7 +1783,7 @@ mod tests {
                             }),
                             RouterContext::new(
                                 handle.clone(),
-                                ProfileStorage::new(&[], &[]),
+                                ProfileStorage::new(&[], &[], None),
                                 router_info.identity.id(),
                                 Bytes::from(router_info.serialize(&signing_key)),
                                 static_key,

--- a/emissary-util/src/storage.rs
+++ b/emissary-util/src/storage.rs
@@ -395,6 +395,7 @@ impl Storage {
                             Some((
                                 name,
                                 emissary_core::Profile {
+                                    is_connected: false,
                                     last_activity: Duration::from_secs(
                                         profile.last_activity.unwrap_or(0),
                                     ),
@@ -480,6 +481,36 @@ impl Storage {
 
         Ok(())
     }
+
+    /// Remove the router info of `router_id` from disk.
+    async fn remove_router_info(&self, router_id: &str) -> anyhow::Result<()> {
+        let dir = router_id.chars().next().ok_or(anyhow!("invalid router id"))?;
+
+        match tokio::fs::remove_file(
+            self.base_path.join(format!("netDb/r{dir}/routerInfo-{router_id}.dat")),
+        )
+        .await
+        {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    /// Remove the profile of `router_id` from disk.
+    async fn remove_profile(&self, router_id: &str) -> anyhow::Result<()> {
+        let dir = router_id.chars().next().ok_or(anyhow!("invalid router id"))?;
+
+        match tokio::fs::remove_file(
+            self.base_path.join(format!("peerProfiles/p{dir}/profile-{router_id}.toml")),
+        )
+        .await
+        {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        }
+    }
 }
 
 impl emissary_core::runtime::Storage for Storage {
@@ -507,6 +538,32 @@ impl emissary_core::runtime::Storage for Storage {
                         ?router_id,
                         ?error,
                         "failed to store router profile to disk",
+                    );
+                }
+            }
+        });
+    }
+
+    fn remove_from_disk(&self, routers: Vec<String>) {
+        let storage_handle = self.clone();
+
+        tokio::spawn(async move {
+            for router_id in routers {
+                if let Err(error) = storage_handle.remove_router_info(&router_id).await {
+                    tracing::warn!(
+                        target: LOG_TARGET,
+                        %router_id,
+                        ?error,
+                        "failed to remove router info from disk"
+                    );
+                }
+
+                if let Err(error) = storage_handle.remove_profile(&router_id).await {
+                    tracing::warn!(
+                        target: LOG_TARGET,
+                        %router_id,
+                        ?error,
+                        "failed to remove router profile from disk"
                     );
                 }
             }


### PR DESCRIPTION
The untracked bucket grew without bounds, holding all `RouterInfo`s discovered during the runtime of the router in memory which resulted in a lot of unnecessary bloat.

Implement culling logic which attempts to keep the untracked bucket at 2000 routers by removing the routers which are not needed by any active connection or bucket.

When the router starts, the untracked bucket is further trimmed down to 2000 routers, based on participation ratio.

Resolves #69 